### PR TITLE
Add support for pronouns

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ Some of these may work but have not been validated with tests.
 - [ ] Comments
 - [ ] The `with` keyword for parameters
 
-## Variables and constants
+## ✓ Variables and constants
 
 - [X] Simple variables
 - [X] Common variables
 - [X] Proper variables
 - [X] Dynamic typing of variables
 - [X] Case insensitivity of variable names
-- [ ] Pronoun variable references
+- [X] Pronoun variable references
 - [X] Number literals
 - [X] Poetic number literals
 - [X] String literals

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -1,6 +1,7 @@
 package org.example;
 
 import io.quarkus.gizmo.ClassOutput;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -239,8 +240,7 @@ names in Rockstar.)
             main.invoke(null, (Object) null);
 
             // Get the captured output as a string
-            String capturedOutput = outputStream.toString();
-            return capturedOutput;
+            return outputStream.toString();
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException | IOException e) {
             throw new RuntimeException(e);
         } finally {
@@ -268,6 +268,46 @@ names in Rockstar.)
         output = compileAndLaunch(program);
 
         assertEquals("goodbye\n", output);
+    }
+
+    @Test
+    public void shouldHandleStringLiteralPronounReferences() {
+        String program = """
+                The message is "pass"
+                say it
+                """;
+
+        String output = compileAndLaunch(program);
+        assertEquals("pass\n", output);
+    }
+
+    @Test
+    public void shouldHandleNumericLiteralPronounReferences() {
+        String program = """
+                Gina is 25
+                say it
+                Shout it
+                Whisper it
+                Scream it
+                                """;
+
+        String output = compileAndLaunch(program);
+        assertEquals("25\n25\n25\n25\n", output);
+    }
+
+    @Disabled("Needs support for plus")
+    @Test
+    public void shouldHandleOperationsOnPronounReferences() {
+        String program = """
+                The message is "pass"
+                say it
+                say it plus "!"
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("pass\n" +
+                "pass!", output);
+
     }
 
 }


### PR DESCRIPTION
Note that there’s an ambiguity in the spec about whether pronouns refer to the last *assigned* variable or the last *mentioned* variable. The text says “Pronouns refer to the last named variable determined by parsing order.”   Satriani, the reference implementation, only updates on assignment, so I’ve amended my implementation to behave the same way. (See discussion in https://github.com/RockstarLang/rockstar/issues/198)

  To align to Satriani, I removed the following implementation code   from my original implementation
  
```
  @Override
public void enterExpression(Rockstar.ExpressionContext ctx) {
    // Pronouns refer to the last named variable determined by parsing order.
    Rockstar.VariableContext variable = ctx.variable();

    trackVariable(variable);
}
```

And the following tests 

```
   @Test
public void shouldHandlePronounReferencesWhenMostRecentReferenceWasNotAssignment() {
    String program = """
            Gina is "g"
            Bob is "b"
            Say it
            Shout Gina
            Whisper it
            Say bob
                            """;

    String output = compileAndLaunch(program);
    assertEquals("b\ng\ng\nb\n", output);
}

@Test
public void shouldHandlePronounReferencesWhenMostRecentReferenceWasNotAssignmentWithCaseVariations() {
    String program = """
            My thing is "g"
            Bob is "b"
            Say it
            Shout my thing
            Whisper it
            Shout MY THING
            Whisper it
            Say bob
                             """;

    String output = compileAndLaunch(program);
    assertEquals("b\ng\ng\ng\ng\nb\n", output);
}
```