### PR TITLE
Add support for increment and decrement

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Some of these may work but have not been validated with tests.
 
 ## Number operations
 
-- [ ] Incrementing and decrementing
+- [X] Incrementing and decrementing
 - [ ] Arithmetic operators
 - [ ] Aliases for arithmetic operators
 - [ ] Compound assignment using `let`

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
@@ -46,11 +46,11 @@ loopStmt: KW_LOOP WS expr=expression NL statementList;
 
 incrementStmt: KW_BUILD WS variable WS ups;
 
-ups: KW_UP (COMMA WS KW_UP)*;
+ups: KW_UP (COMMA? WS+ KW_UP)*;
 
 decrementStmt: KW_KNOCK WS variable WS downs;
 
-downs: KW_DOWN (COMMA WS KW_DOWN)*;
+downs: KW_DOWN (COMMA? WS+ KW_DOWN)*;
 
 returnStmt: KW_GIVE WS KW_BACK WS expression;
 

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
@@ -77,48 +77,59 @@ public class BytecodeGeneratingListener extends RockstarBaseListener {
     public void enterIncrementStmt(Rockstar.IncrementStmtContext ctx) {
         Rockstar.VariableContext variable = ctx.variable();
 
-        // TODO this is assuming integers, also need to handle strings and doubles
-        ResultHandle value = getVariable(variable);
-        ResultHandle incremented;
-        try {
-            // This is ugly, but the result handle does not expose the method to get the type publicly, so we need trial and error
-            // (or to track it ourselves)
-            // TODO According to the spec, all numbers are actually double, and so in principle we should always increment with 1.0, but
-            //  that's not what's implemented now
-            incremented = main.increment(value);
-        } catch (RuntimeException e) {
-            try {
-                incremented = main.add(value, main.load((double) 1));
-            } catch (RuntimeException ee) {
-                // This must be a string
-                ResultHandle constant = main.load("1");
-                incremented = main.invokeVirtualMethod(
-                        MethodDescriptor.ofMethod("java/lang/String", "concat", "Ljava/lang/String;", "Ljava/lang/String;"), value,
-                        constant);
-            }
-        }
+        int count = ctx.ups()
+                       .KW_UP()
+                       .size();
 
-        writeVariable(variable, incremented);
+        for (int i = 0; i < count; i++) {
+
+            ResultHandle value = getVariable(variable);
+            ResultHandle incremented;
+            try {
+                // This is ugly, but the result handle does not expose the method to get the type publicly, so we need trial and error
+                // (or to track it ourselves)
+                // TODO According to the spec, all numbers are actually double, and so in principle we should always increment with 1.0, but
+                //  that's not what's implemented now
+                incremented = main.increment(value);
+            } catch (RuntimeException e) {
+                try {
+                    incremented = main.add(value, main.load((double) 1));
+                } catch (RuntimeException ee) {
+                    // This must be a string
+                    ResultHandle constant = main.load("1");
+                    incremented = main.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod("java/lang/String", "concat", "Ljava/lang/String;", "Ljava/lang/String;"), value,
+                            constant);
+                }
+            }
+
+            writeVariable(variable, incremented);
+        }
     }
 
     @Override
     public void enterDecrementStmt(Rockstar.DecrementStmtContext ctx) {
         Rockstar.VariableContext variable = ctx.variable();
 
-        // TODO this is assuming integers, also need to handle strings and doubles
-        ResultHandle value = getVariable(variable);
-        ResultHandle incremented;
-        try {
-            // This is ugly, but the result handle does not expose the method to get the type publicly, so we need trial and error
-            // (or to track it ourselves)
-            // TODO According to the spec, all numbers are actually double, and so in principle we should always increment with 1.0, but
-            //  that's not what's implemented now
-            incremented = main.add(value, main.load(-1));
-        } catch (RuntimeException e) {
-            incremented = main.add(value, main.load((double) -1));
-        }
+        int count = ctx.downs()
+                       .KW_DOWN()
+                       .size();
 
-        writeVariable(variable, incremented);
+        for (int i = 0; i < count; i++) {
+            ResultHandle value = getVariable(variable);
+            ResultHandle incremented;
+            try {
+                // This is ugly, but the result handle does not expose the method to get the type publicly, so we need trial and error
+                // (or to track it ourselves)
+                // TODO According to the spec, all numbers are actually double, and so in principle we should always increment with 1.0, but
+                //  that's not what's implemented now
+                incremented = main.add(value, main.load(-1));
+            } catch (RuntimeException e) {
+                incremented = main.add(value, main.load((double) -1));
+            }
+
+            writeVariable(variable, incremented);
+        }
     }
 
     private void writeVariable(Rockstar.VariableContext variable, ResultHandle value) {

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
@@ -101,6 +101,26 @@ public class BytecodeGeneratingListener extends RockstarBaseListener {
         writeVariable(variable, incremented);
     }
 
+    @Override
+    public void enterDecrementStmt(Rockstar.DecrementStmtContext ctx) {
+        Rockstar.VariableContext variable = ctx.variable();
+
+        // TODO this is assuming integers, also need to handle strings and doubles
+        ResultHandle value = getVariable(variable);
+        ResultHandle incremented;
+        try {
+            // This is ugly, but the result handle does not expose the method to get the type publicly, so we need trial and error
+            // (or to track it ourselves)
+            // TODO According to the spec, all numbers are actually double, and so in principle we should always increment with 1.0, but
+            //  that's not what's implemented now
+            incremented = main.add(value, main.load(-1));
+        } catch (RuntimeException e) {
+            incremented = main.add(value, main.load((double) -1));
+        }
+
+        writeVariable(variable, incremented);
+    }
+
     private void writeVariable(Rockstar.VariableContext variable, ResultHandle value) {
         String variableName = getVariableName(variable);
         FieldDescriptor field = variables.get(variableName);

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -278,9 +278,20 @@ names in Rockstar.)
         assertEquals("2\n", output);
     }
 
-    @Disabled("Repeated increments in the same statement not supported by grammar, yet")
     @Test
-    public void shouldHandleIncrementForRepetitionCase() {
+    public void shouldHandleIncrementForRepetitionWithCommasCase() {
+        String program = """
+                My world is 0
+                Build my world up, up, up
+                Say my world
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("3\n", output);
+    }
+
+    @Test
+    public void shouldHandleIncrementForRepetitionWithoutCommasCase() {
         String program = """
                 My world is 0
                 Build my world up, up up
@@ -288,7 +299,7 @@ names in Rockstar.)
                 """;
         String output = compileAndLaunch(program);
 
-        assertEquals("2\n", output);
+        assertEquals("3\n", output);
     }
 
 
@@ -357,6 +368,30 @@ names in Rockstar.)
 
         // Floating points are hard! Satriani also gives this as -0.5800000000000001, and a simple "1.42 - 2.0" also gives that result
         assertEquals("-0.5800000000000001\n", output);
+    }
+
+    @Test
+    public void shouldHandleDecrementForRepetitionWithCommasCase() {
+        String program = """
+                My world is 4
+                Knock my world down, down, down
+                Say my world
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("1\n", output);
+    }
+
+    @Test
+    public void shouldHandleDecrementForRepetitionWithoutCommasCase() {
+        String program = """
+                My world is 4
+                Knock my world down down, down
+                Say my world
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("1\n", output);
     }
 
     @Test

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -264,7 +264,74 @@ names in Rockstar.)
                 "pass!", output);
 
     }
-    
+
+    @Test
+    public void shouldHandleIncrementForSimpleCase() {
+        String program = """
+                My world is 0
+                Build my world up
+                Build my world up
+                Say my world
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("2\n", output);
+    }
+
+    @Disabled("Repeated increments in the same statement not supported by grammar, yet")
+    @Test
+    public void shouldHandleIncrementForRepetitionCase() {
+        String program = """
+                My world is 0
+                Build my world up, up up
+                Say my world
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("2\n", output);
+    }
+
+
+    @Test
+    public void shouldHandleIncrementForPronounCase() {
+        String program = """
+                My world is 0
+                Build it up
+                Build it up
+                Say my world
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("2\n", output);
+
+    }
+
+    @Test
+    public void shouldHandleIncrementForDecimalCase() {
+        String program = """
+                My world is 3.141
+                Build my world up
+                Build my world up
+                Say my world
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("5.141\n", output);
+    }
+
+    @Test
+    public void shouldHandleIncrementForStringCase() {
+        String program = """
+                My world is "hello"
+                Build my world up
+                Build my world up
+                Say my world
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("hello11\n", output);
+    }
+
     private String compileAndLaunch(String program) {
         // Save the current System.out for later restoration
         PrintStream originalOut = System.out;

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -295,14 +295,14 @@ names in Rockstar.)
     @Test
     public void shouldHandleIncrementForPronounCase() {
         String program = """
-                My world is 0
+                My world is 1
                 Build it up
                 Build it up
                 Say my world
                 """;
         String output = compileAndLaunch(program);
 
-        assertEquals("2\n", output);
+        assertEquals("3\n", output);
 
     }
 
@@ -320,6 +320,46 @@ names in Rockstar.)
     }
 
     @Test
+    public void shouldHandleDecrementForSimpleCase() {
+        String program = """
+                The walls is 0
+                Knock the walls down
+                Knock the walls down
+                Shout the walls
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("-2\n", output);
+    }
+
+    @Test
+    public void shouldHandleDecrementForPronounCase() {
+        String program = """
+                The walls is 1
+                Knock them down
+                Knock them down
+                Shout the walls
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("-1\n", output);
+    }
+
+    @Test
+    public void shouldHandleDecrementForDecimalCase() {
+        String program = """
+                The walls is 1.42
+                Knock the walls down
+                Knock the walls down
+                Shout the walls
+                """;
+        String output = compileAndLaunch(program);
+
+        // Floating points are hard! Satriani also gives this as -0.5800000000000001, and a simple "1.42 - 2.0" also gives that result
+        assertEquals("-0.5800000000000001\n", output);
+    }
+
+    @Test
     public void shouldHandleIncrementForStringCase() {
         String program = """
                 My world is "hello"
@@ -331,6 +371,8 @@ names in Rockstar.)
 
         assertEquals("hello11\n", output);
     }
+
+    // No need for decrement for a string, it's NaN in Satriani
 
     private String compileAndLaunch(String program) {
         // Save the current System.out for later restoration

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
@@ -20,11 +20,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ParseHelper {
 
     public static Rockstar.AssignmentStmtContext getAssignment(String program) {
-        return (Rockstar.AssignmentStmtContext) getGrammarElement(program, (CapturingListener l) -> l.getAssignmentStatement());
+        return (Rockstar.AssignmentStmtContext) getGrammarElement(program, CapturingListener::getAssignmentStatement);
     }
 
     public static Rockstar.PoeticNumberLiteralContext getPoeticNumberLiteral(String program) {
-        return (Rockstar.PoeticNumberLiteralContext) getGrammarElement(program, (CapturingListener l) -> l.getPoeticNumberLiteral());
+        return (Rockstar.PoeticNumberLiteralContext) getGrammarElement(program, CapturingListener::getPoeticNumberLiteral);
     }
 
     private static RuleContext getGrammarElement(String program, Function<CapturingListener,


### PR DESCRIPTION
The spec says:

> Increment and Decrement
Increment and decrement are supported by the Build {variable} up and Knock {variable} down statements. Adding more than one up or down in the statement will increment or decrement the same amount of times as you have ups or downs in the statement. There may be a comma between each up and down.
> * Build my world up will increment the value stored in my world by 1.
> * Knock the walls down will decrement the value stored in the walls by 1
> * Knock the walls down, down will decrement the value stored in the walls by 2

All of this is now working. :)


