### PR TITLE
Use double for all numbers (plus refactoring)

### DIFF
--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Constant.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Constant.java
@@ -1,0 +1,36 @@
+package org.example;
+
+import rock.Rockstar;
+
+public class Constant {
+    private Class<?> valueClass;
+    private Object value;
+
+    public Constant(Rockstar.ConstantContext constant) {
+
+        if (constant != null) {
+            if (constant
+                    .CONSTANT_TRUE() != null) {
+                value = true;
+                valueClass = boolean.class;
+            } else if (constant
+                    .CONSTANT_FALSE() != null) {
+                value = false;
+                valueClass = boolean.class;
+            } else if (constant
+                    .CONSTANT_EMPTY() != null) {
+                value = "";
+                valueClass = String.class;
+            }
+        }
+    }
+
+
+    public Object getValue() {
+        return value;
+    }
+
+    public Class<?> getValueClass() {
+        return valueClass;
+    }
+}

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Expression.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Expression.java
@@ -1,0 +1,93 @@
+package org.example;
+
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import rock.Rockstar;
+
+public class Expression {
+
+    private Class<?> valueClass;
+    private Object value;
+    private Variable variable;
+
+    public Expression(Rockstar.ExpressionContext ctx) {
+        if (ctx != null) {
+            Rockstar.LiteralContext literal = ctx.literal();
+            Rockstar.ConstantContext constant = ctx.constant();
+            Rockstar.VariableContext variableContext = ctx.variable();
+
+            if (literal != null) {
+                if (literal
+                        .NUMERIC_LITERAL() != null) {
+
+                    TerminalNode num = literal
+                            .NUMERIC_LITERAL();
+                    //  Numbers in Rockstar are double-precision floating point numbers, stored according to the IEEE 754 standard.
+                    // ... so we don't need to worry about integers
+                    value = Double.parseDouble(num.getText());
+
+                    valueClass = double.class;
+
+                } else if (literal
+                        .STRING_LITERAL() != null) {
+                    value = literal
+                            .STRING_LITERAL()
+                            .getText()
+                            .replaceAll("\"", "");
+                    // Strip out the quotes around literals (doing it in the listener rather than the lexer is simpler, and apparently
+                    // idiomatic-ish)
+                    valueClass = String.class;
+                }
+
+            } else if (constant != null) {
+                if (constant
+                        .CONSTANT_TRUE() != null) {
+                    value = true;
+                    valueClass = boolean.class;
+                } else if (constant
+                        .CONSTANT_FALSE() != null) {
+                    value = false;
+                    valueClass = boolean.class;
+                } else if (constant
+                        .CONSTANT_EMPTY() != null) {
+                    value = "";
+                    valueClass = String.class;
+                }
+
+
+            } else if (variableContext != null) {
+                variable = new Variable(variableContext);
+                value = variable.getVariableName();
+                // A somewhat arbitrary choice, but at least it's a marker
+                valueClass = Variable.class;
+
+            }
+        }
+    }
+
+
+    public Object getValue() {
+        return value;
+    }
+
+    public Class<?> getValueClass() {
+        return valueClass;
+    }
+
+    public ResultHandle getResultHandle(MethodCreator method) {
+        if (variable != null) {
+            return variable.read(method);
+        } else {
+            // This is a literal
+            if (String.class.equals(valueClass)) {
+                return method.load((String) value);
+            } else if (double.class.equals(valueClass)) {
+                return method.load((double) value);
+            } else if (boolean.class.equals(valueClass)) {
+                return method.load((boolean) value);
+            }
+        }
+        throw new RuntimeException("Could not interpret type " + valueClass);
+    }
+}

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Literal.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Literal.java
@@ -1,0 +1,45 @@
+package org.example;
+
+import org.antlr.v4.runtime.tree.TerminalNode;
+import rock.Rockstar;
+
+public class Literal {
+    private Class<?> valueClass;
+    private Object value;
+
+    public Literal(Rockstar.LiteralContext literal) {
+
+        if (literal != null) {
+            if (literal
+                    .NUMERIC_LITERAL() != null) {
+
+                TerminalNode num = literal
+                        .NUMERIC_LITERAL();
+                //  Numbers in Rockstar are double-precision floating point numbers, stored according to the IEEE 754 standard.
+                // ... so we don't need to worry about integers
+                value = Double.parseDouble(num.getText());
+
+                valueClass = double.class;
+
+            } else if (literal
+                    .STRING_LITERAL() != null) {
+                value = literal
+                        .STRING_LITERAL()
+                        .getText()
+                        .replaceAll("\"", "");
+                // Strip out the quotes around literals (doing it in the listener rather than the lexer is simpler, and apparently
+                // idiomatic-ish)
+                valueClass = String.class;
+            }
+        }
+    }
+
+
+    public Object getValue() {
+        return value;
+    }
+
+    public Class<?> getValueClass() {
+        return valueClass;
+    }
+}

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
@@ -1,0 +1,109 @@
+package org.example;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.objectweb.asm.Opcodes;
+import rock.Rockstar;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Variable {
+    // Because this is static, we could get cross-talk between programs, but that's a relatively low risk; we manage it by explicitly
+    // clearing statics
+    private static String mostRecentVariableName = null;
+    private static final Map<String, FieldDescriptor> variables = new HashMap<>();
+
+    private final String variableName;
+
+    public Variable(Rockstar.VariableContext variable) {
+
+        // Work out the variable name
+        // In principle trivial, in practice made a bit complicated by normalisation and more complicated by pronouns
+
+        TerminalNode pronouns = variable.PRONOUNS();
+        if (pronouns != null) {
+            if (mostRecentVariableName == null) {
+                // This could be an internal error or a program one
+                throw new RuntimeException("No good: Unassociated pronoun");
+            }
+            variableName = mostRecentVariableName;
+
+        } else {
+            String text = variable
+                    .getText();
+            variableName = text.toLowerCase();
+        }
+    }
+
+    public String getVariableName() {
+        return variableName;
+    }
+
+    /**
+     * This is useful for things like variable names in bytecode, where spaces are not ok
+     */
+    private String getNormalisedVariableName() {
+        return variableName
+                .replace(" ", "__") // use two underscores to reduce the chance of a clash with variable names in the program
+                .toLowerCase();
+    }
+
+    /*
+       Pronouns refer to the last named variable determined by parsing order.
+       In practice, this is only on assignment, not on any reference, so this needs to be triggered externally.
+     */
+    public void track() {
+        if (variableName != null) {
+            mostRecentVariableName = variableName;
+        }
+    }
+
+    public static void clearPronouns() {
+        mostRecentVariableName = null;
+        variables.clear();
+    }
+
+
+    public ResultHandle read(MethodCreator method) {
+        if (variables.containsKey(variableName)) {
+            return method.readStaticField(variables.get(variableName));
+
+        } else {
+            // This is an internal error, not a program one
+            throw new RuntimeException("Moral panic: Could not find variable called " + variableName);
+        }
+    }
+
+    public void write(MethodCreator method, ResultHandle value) {
+        FieldDescriptor field = variables.get(variableName);
+
+        method.writeStaticField(field, value);
+    }
+
+    // TODO if we use local variables we can drop passing the class creator
+    // TODO would it be nicer to store our own class?
+    public FieldDescriptor getField(ClassCreator creator, MethodCreator method, Class<?> clazz) {
+        FieldDescriptor field;
+
+        if (!variables.containsKey(variableName)) {
+
+            String javaCompliantName = getNormalisedVariableName();
+
+            // It's not strictly necessary to use a field rather than a local variable, but I wasn't sure how to do local variables
+            field = creator.getFieldCreator(javaCompliantName, clazz)
+                           .setModifiers(Opcodes.ACC_STATIC + Opcodes.ACC_PRIVATE)
+                           .getFieldDescriptor();
+            variables.put(variableName, field);
+        } else {
+            field = variables.get(variableName);
+        }
+        return field;
+    }
+
+
+}
+

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/grammar/PoeticNumberLiteral.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/grammar/PoeticNumberLiteral.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 public class PoeticNumberLiteral {
     private final Class<?> variableClass;
 
-    final Number value;
+    final double value;
 
     public PoeticNumberLiteral(Rockstar.PoeticNumberLiteralContext ctx) {
         // A poetic number literal begins with a variable name, followed by the keyword is , or the aliases are , was or were .
@@ -48,7 +48,8 @@ public class PoeticNumberLiteral {
             variableClass = double.class;
             value = Double.parseDouble(string);
         } else {
-            variableClass = int.class;
+            variableClass = double.class;
+            // We can parse as an int, and then store as a double
             value = Integer.parseInt(string);
         }
 

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -26,6 +26,21 @@ public class BytecodeGeneratorTest {
         assertEquals("Hello San Francisco\n", output);
     }
 
+    @Test
+    public void shouldHandleSimpleNumericLiterals() {
+        String program = "Shout 31";
+        String output = compileAndLaunch(program);
+        assertEquals("31\n", output);
+
+        // Output should be rounded even of entered with decimals
+        program = "Shout 34.0";
+        output = compileAndLaunch(program);
+        assertEquals("34\n", output);
+
+        program = "Shout 34.2";
+        output = compileAndLaunch(program);
+        assertEquals("34.2\n", output);
+    }
 
     /*
     Simple variables are valid identifiers that are not language keywords. A simple variable name must contain only letters, and cannot
@@ -133,6 +148,7 @@ names in Rockstar.)
                                             """;
         String output = compileAndLaunch(program);
 
+        // Even though is stored as a double internally, we want (and the spec expects) an integer-format output
         assertEquals("5\n", output);
     }
 
@@ -367,7 +383,9 @@ names in Rockstar.)
         String output = compileAndLaunch(program);
 
         // Floating points are hard! Satriani also gives this as -0.5800000000000001, and a simple "1.42 - 2.0" also gives that result
-        assertEquals("-0.5800000000000001\n", output);
+        // Here, because we have to round to handle integers correctly, we can set a maximum precision that's shorter than the point
+        // where floats go weird
+        assertEquals("-0.58\n", output);
     }
 
     @Test

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/ConstantTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/ConstantTest.java
@@ -1,0 +1,104 @@
+package org.example;
+
+import org.example.util.ParseHelper;
+import org.junit.jupiter.api.Test;
+import rock.Rockstar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ConstantTest {
+
+
+    /*
+    empty , silent , and silence are aliases for the empty string ( "" ).
+     */
+    @Test
+    public void shouldParseEmptyStringAliases() {
+        Rockstar.ConstantContext ctx = ParseHelper.getConstant("life is silence");
+        Constant a = new Constant(ctx);
+        assertEquals("", a.getValue());
+        assertEquals(String.class, a.getValueClass());
+
+        ctx = ParseHelper.getConstant("life is silent");
+        a = new Constant(ctx);
+        assertEquals("", a.getValue());
+
+        ctx = ParseHelper.getConstant("life is empty");
+        a = new Constant(ctx);
+        assertEquals("", a.getValue());
+    }
+
+
+    @Test
+    public void shouldParseBooleanConstantsForTrueCase() {
+        Rockstar.ConstantContext ctx = ParseHelper.getConstant("life is true");
+        Constant a = new Constant(ctx);
+        assertEquals(true, a.getValue());
+        assertEquals(boolean.class, a.getValueClass());
+
+        ctx = ParseHelper.getConstant("life is right");
+        a = new Constant(ctx);
+        assertEquals(true, a.getValue());
+
+        ctx = ParseHelper.getConstant("life is ok");
+        a = new Constant(ctx);
+        assertEquals(true, a.getValue());
+
+        ctx = ParseHelper.getConstant("life is yes");
+        a = new Constant(ctx);
+        assertEquals(true, a.getValue());
+    }
+
+    @Test
+    public void shouldParseBooleanConstantsForFalseCase() {
+        Rockstar.ConstantContext ctx = ParseHelper.getConstant("life is false");
+        Constant a = new Constant(ctx);
+        assertEquals(false, a.getValue());
+        assertEquals(boolean.class, a.getValueClass());
+
+        ctx = ParseHelper.getConstant("life is lies");
+        a = new Constant(ctx);
+        assertEquals(false, a.getValue());
+
+        ctx = ParseHelper.getConstant("life is wrong");
+        a = new Constant(ctx);
+        assertEquals(false, a.getValue());
+
+        ctx = ParseHelper.getConstant("life is no");
+        a = new Constant(ctx);
+        assertEquals(false, a.getValue());
+    }
+
+    /*
+    Rockstar makes a distinction between `null` and `undefined`. Javascript also does this,
+    but since Java does not, we will ignore that for the moment.
+     */
+    @Test
+    public void shouldParseUndefinedConstants() {
+        Rockstar.ConstantContext ctx = ParseHelper.getConstant("life is mysterious");
+        Constant a = new Constant(ctx);
+        assertNull(a.getValue());
+        // Not great, but the best we can do
+    }
+
+    @Test
+    public void shouldParseNullConstants() {
+        Rockstar.ConstantContext ctx = ParseHelper.getConstant("life is nothing");
+        Constant a = new Constant(ctx);
+        assertNull(a.getValue());
+
+        ctx = ParseHelper.getConstant("life is nobody");
+        a = new Constant(ctx);
+        assertNull(a.getValue());
+
+        ctx = ParseHelper.getConstant("life is nowhere");
+        a = new Constant(ctx);
+        assertNull(a.getValue());
+
+        ctx = ParseHelper.getConstant("life is gone");
+        a = new Constant(ctx);
+        assertNull(a.getValue());
+    }
+
+}

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
@@ -1,0 +1,180 @@
+package org.example;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import org.example.util.ParseHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import rock.Rockstar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+Note that even though we're just testing the expressions, they need to be couched in something like output statement to be
+recognised.
+ */
+public class ExpressionTest {
+
+    @BeforeEach
+    public void clearState() {
+        Variable.clearPronouns();
+    }
+
+    @Test
+    public void shouldParseIntegerLiterals() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout 5");
+        Expression a = new Expression(ctx);
+        // The number should be stored as a double, even though it was entered as an integer
+        assertEquals(5d, a.getValue());
+        assertEquals(double.class, a.getValueClass());
+    }
+
+    @Test
+    public void shouldParseIntegerLiteralsAsVariables() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("my thing is 5\nshout my thing");
+        Expression a = new Expression(ctx);
+        // The 'value' is the variable name
+        assertEquals("my thing", a.getValue());
+        // A bit clunky, but finding an optimum value is non-obvious
+        assertEquals(Variable.class, a.getValueClass());
+    }
+
+    /* Numbers in Rockstar are double-precision floating point numbers, stored according to the IEEE 754 standard.*/
+    @Test
+    public void shouldParseFloatingPointLiterals() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout 3.141");
+        Expression a = new Expression(ctx);
+        assertEquals(3.141, a.getValue());
+        assertEquals(double.class, a.getValueClass());
+    }
+
+    /*
+empty , silent , and silence are aliases for the empty string ( "" ).
+ */
+    @Test
+    public void shouldParseEmptyStringAliases() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout silence");
+        Expression a = new Expression(ctx);
+        assertEquals("", a.getValue());
+        assertEquals(String.class, a.getValueClass());
+
+        ctx = ParseHelper.getExpression("shout silent");
+        a = new Expression(ctx);
+        assertEquals("", a.getValue());
+
+        ctx = ParseHelper.getExpression("shout empty");
+        a = new Expression(ctx);
+        assertEquals("", a.getValue());
+    }
+
+
+    @Test
+    public void shouldParseBooleanLiteralsForTrueCase() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout true");
+        Expression a = new Expression(ctx);
+        assertEquals(true, a.getValue());
+        assertEquals(boolean.class, a.getValueClass());
+
+        ctx = ParseHelper.getExpression("shout right");
+        a = new Expression(ctx);
+        assertEquals(true, a.getValue());
+
+        ctx = ParseHelper.getExpression("shout ok");
+        a = new Expression(ctx);
+        assertEquals(true, a.getValue());
+
+        ctx = ParseHelper.getExpression("shout yes");
+        a = new Expression(ctx);
+        assertEquals(true, a.getValue());
+    }
+
+    @Test
+    public void shouldParseBooleanLiteralsForFalseCase() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout false");
+        Expression a = new Expression(ctx);
+        assertEquals(false, a.getValue());
+        assertEquals(boolean.class, a.getValueClass());
+
+        ctx = ParseHelper.getExpression("shout lies");
+        a = new Expression(ctx);
+        assertEquals(false, a.getValue());
+
+        ctx = ParseHelper.getExpression("shout wrong");
+        a = new Expression(ctx);
+        assertEquals(false, a.getValue());
+
+        ctx = ParseHelper.getExpression("shout no");
+        a = new Expression(ctx);
+        assertEquals(false, a.getValue());
+    }
+
+    @Test
+    public void shouldParseNullConstants() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout nothing");
+        Expression a = new Expression(ctx);
+        assertNull(a.getValue());
+
+        ctx = ParseHelper.getExpression("shout nobody");
+        a = new Expression(ctx);
+        assertNull(a.getValue());
+
+        ctx = ParseHelper.getExpression("shout nowhere");
+        a = new Expression(ctx);
+        assertNull(a.getValue());
+
+        ctx = ParseHelper.getExpression("shout gone");
+        a = new Expression(ctx);
+        assertNull(a.getValue());
+    }
+
+    @Test
+    public void shouldCreateResultHandlesOfTheCorrectTypeForStrings() {
+        ClassCreator creator = ClassCreator.builder()
+                                           .className("holder")
+                                           .build();
+        MethodCreator main = creator.getMethodCreator("main", void.class, String[].class);
+
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout \"hello\"");
+        ResultHandle handle = new Expression(ctx).getResultHandle(main);
+
+        // We can't interrogate the type directly, so read it from the string
+        assertTrue(handle.toString()
+                         .contains("type='Ljava/lang/String;'"), handle.toString());
+
+    }
+
+    @Test
+    public void shouldCreateResultHandlesOfTheCorrectTypeForNumbers() {
+        ClassCreator creator = ClassCreator.builder()
+                                           .className("holder")
+                                           .build();
+        MethodCreator main = creator.getMethodCreator("main", void.class, String[].class);
+
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout 5");
+        ResultHandle handle = new Expression(ctx).getResultHandle(main);
+
+        // We can't interrogate the type directly, so read it from the string
+        assertTrue(handle.toString()
+                         .contains("type='D'"), handle.toString());
+
+    }
+
+    @Test
+    public void shouldCreateResultHandlesOfTheCorrectTypeForBooleans() {
+        ClassCreator creator = ClassCreator.builder()
+                                           .className("holder")
+                                           .build();
+        MethodCreator main = creator.getMethodCreator("main", void.class, String[].class);
+
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout ok");
+        ResultHandle handle = new Expression(ctx).getResultHandle(main);
+
+        // We can't interrogate the type directly, so read it from the string
+        assertTrue(handle.toString()
+                         .contains("type='Z'"), handle.toString());
+
+    }
+}

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/LiteralTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/LiteralTest.java
@@ -1,0 +1,40 @@
+package org.example;
+
+import org.example.util.ParseHelper;
+import org.junit.jupiter.api.Test;
+import rock.Rockstar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/*
+Note: The programs here need some context outside the literal, such as an assignment or an output statement, to be recognised by the
+grammar.
+ Note also that poetic string and poetic literals are not handled by the literal class. */
+public class LiteralTest {
+
+    @Test
+    public void shouldParseIntegerLiterals() {
+        Rockstar.LiteralContext ctx = ParseHelper.getLiteral("thing is 5");
+        Literal a = new Literal(ctx);
+        // The number should be stored as a double, even though it was entered as an integer
+        assertEquals(5d, a.getValue());
+        assertEquals(double.class, a.getValueClass());
+    }
+
+    /* Numbers in Rockstar are double-precision floating point numbers, stored according to the IEEE 754 standard.*/
+    @Test
+    public void shouldParseFloatingPointLiterals() {
+        Rockstar.LiteralContext ctx = ParseHelper.getLiteral("thing is 3.141");
+        Literal a = new Literal(ctx);
+        assertEquals(3.141, a.getValue());
+        assertEquals(double.class, a.getValueClass());
+    }
+
+    @Test
+    public void shouldParseStringLiterals() {
+        Rockstar.LiteralContext ctx = ParseHelper.getLiteral("thing is \"Yes hello\"");
+        Literal a = new Literal(ctx);
+        assertEquals("Yes hello", a.getValue());
+        assertEquals(String.class, a.getValueClass());
+    }
+}

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/VariableTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/VariableTest.java
@@ -1,0 +1,247 @@
+package org.example;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import org.example.util.ParseHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import rock.Rockstar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class VariableTest {
+
+    @BeforeEach
+    public void clearState() {
+        Variable.clearPronouns();
+    }
+
+    @Test
+    public void shouldParseIntegerLiteralsAsVariables() {
+        Rockstar.VariableContext ctx = ParseHelper.getVariable("my thing is 5\nshout my thing");
+        Variable a = new Variable(ctx);
+        // The 'value' is the variable name
+        assertEquals("my thing", a.getVariableName());
+
+    }
+
+
+    /*
+    Simple variables are valid identifiers that are not language keywords. A simple variable name must contain only letters, and cannot
+    contain spaces.
+     */
+    @Test
+    public void shouldHandleSimpleVariableNames() {
+        String program = """
+                Variable is "Hello San Francisco"
+                Shout Variable
+                                            """;
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+
+        assertEquals("variable", v.getVariableName());
+    }
+
+    /*
+     Common variables consist of one of the keywords a , an , the , my , your or our followed by whitespace and a unique variable name,
+     which must contain only lowercase ASCII letters a-z. The keyword is part of the variable name, so a boy is a different variable from
+      the boy . Common variables are case-insensitive.
+     */
+    @Test
+    public void shouldHandleCommonVariableNames() {
+        String program = """
+                My thing is true
+                Shout my thing
+                                            """;
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+        assertEquals("my thing", v.getVariableName());
+    }
+
+    /*
+    Proper variables are multi-word proper nouns - words that aren't language keywords, each starting with an uppercase letter, separated
+     by spaces. (Single-word variables are always simple variables.) Whilst some developers may use this feature to create variables with
+      names like Customer ID , Tax Rate or Distance In KM , we recommend you favour idiomatic variable names such as
+Doctor Feelgood , Mister Crowley , Tom Sawyer , and Billie Jean .
+(Although not strictly idiomatic, Eleanor Rigby , Peggy Sue , Black Betty , and Johnny B Goode would also all be valid variable
+names in Rockstar.)
+     */
+    @Test
+    public void shouldHandleProperVariableNames() {
+        String program = """
+                Doctor Feelgood is a good fellow
+                Shout Doctor Feelgood
+                Shout Doctor FeelGOOD
+                                            """;
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+        assertEquals("doctor feelgood", v.getVariableName());
+    }
+
+    @Test
+    public void shouldTreatVariableNamesAsCaseInsensitive() {
+        String program = """
+                tIMe is an illusion
+                                            """;
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+        assertEquals("time", v.getVariableName());
+    }
+
+    @Test
+    public void shouldAllowAllUpperCaseVariableNames() {
+        String program = """
+                TIME is an illusion
+                                            """;
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+        assertEquals("time", v.getVariableName());
+    }
+
+    /*
+ Common variables consist of one of the keywords a , an , the , my , your or our followed by whitespace and a unique variable name,
+ which must contain only lowercase ASCII letters a-z. The keyword is part of the variable name, so a boy is a different variable from
+  the boy . Common variables are case-insensitive.
+ */
+    @Test
+    public void shouldMultiWordVariableNames() {
+        String program = """
+                My thing is true
+                Shout my thing
+                                            """;
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+        assertEquals("my thing", v.getVariableName());
+    }
+
+
+    /*
+     * This is the starting example on https://codewithrockstar.com/online
+     * It exercises variables, poetic number literals, and console output
+     */
+    @Test
+    public void shouldHandleVariableAssignmentToPoeticNumberLiterals() {
+        String program = "Rockstar is a big bad monster";
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+
+        assertEquals("rockstar", v.getVariableName());
+    }
+
+    /*
+     * Put 123 into X will assign the value 123 to the variable X
+     */
+    @Test
+    public void shouldHandlePutIntoVariableAssignment() {
+        String program = """
+                Put 123 into X
+                Shout X
+                """;
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+        assertEquals("x", v.getVariableName());
+    }
+
+
+    /*
+     *  Let my balance be 1000000 will store the value 1000000 in the variable my balance
+     */
+    @Test
+    public void shouldHandleLetVariableAssignment() {
+        String program = """
+                Let my balance be 1000000
+                Shout my balance
+                """;
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+        assertEquals("my balance", v.getVariableName());
+    }
+
+
+    @Test
+    public void shouldHandleStringLiteralPronounReferences() {
+
+        // This is a bit of a convoluted test, because the thin skeleton we're using for creating the variable does invoke other parts of
+        // the parse logic, such as assignments
+
+        String program = "The message is \"pass\"";
+        Rockstar.VariableContext ctx = ParseHelper.getVariable(program);
+        Variable v = new Variable(ctx);
+        v.track();
+
+        program = "shout it";
+
+        ctx = ParseHelper.getVariable(program);
+        v = new Variable(ctx);
+
+        // Now go again and make sure we can interpret the pronoun
+        assertEquals("the message", v.getVariableName());
+    }
+
+    @Test
+    public void shouldRoundTripValuesThroughWritingAndReading() {
+        ClassCreator creator = ClassCreator.builder()
+                                           .className("holder")
+                                           .build();
+        MethodCreator method = creator.getMethodCreator("main", void.class, String[].class);
+
+        Rockstar.VariableContext ctx = ParseHelper.getVariable("johnny is cool");
+        Variable variable = new Variable(ctx);
+        ResultHandle writtenValue = method.load("whatever");
+        // We need to initialise the field before trying to write to it (yuck, clunk)
+        // TODO should we maybe try and streamline that in the variable class, or is this the logical flow?
+        FieldDescriptor field = variable.getField(creator, method, String.class);
+        variable.write(method, writtenValue);
+        ResultHandle readValue = variable.read(method);
+
+        // Ignore the number in our comparison
+        readValue.setNo(0);
+        writtenValue.setNo(0);
+
+        // There is not an equals implementation beyond ==, so just compare the strings
+        assertEquals(writtenValue.toString(), readValue.toString());
+
+    }
+
+    @Test
+    public void shouldCreateAndReuseFields() {
+        ClassCreator creator = ClassCreator.builder()
+                                           .className("holder")
+                                           .build();
+        MethodCreator method = creator.getMethodCreator("main", void.class, String[].class);
+
+        Rockstar.VariableContext ctx = ParseHelper.getVariable("fred is 5");
+        Variable variable = new Variable(ctx);
+
+        FieldDescriptor field1 = variable.getField(creator, method, Object.class);
+        assertNotNull(field1);
+
+        // Now a second variable instance with the same name should return the same field
+        ctx = ParseHelper.getVariable("fred is 8");
+        variable = new Variable(ctx);
+
+        FieldDescriptor field2 = variable.getField(creator, method, Object.class);
+        assertSame(field1, field2);
+
+    }
+
+    @Test
+    public void shouldGenerateAJavaCompliantVariableName() {
+        ClassCreator creator = ClassCreator.builder()
+                                           .className("holder")
+                                           .build();
+        MethodCreator method = creator.getMethodCreator("main", void.class, String[].class);
+
+        Rockstar.VariableContext ctx = ParseHelper.getVariable("My thing is 6");
+        Variable variable = new Variable(ctx);
+
+        FieldDescriptor field = variable.getField(creator, method, Object.class);
+        assertEquals("my__thing", field.getName());
+    }
+
+
+}

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/grammar/PoeticNumberLiteralTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/grammar/PoeticNumberLiteralTest.java
@@ -13,40 +13,40 @@ public class PoeticNumberLiteralTest {
     public void shouldParseIntegerPoeticNumberLiterals() {
         Rockstar.PoeticNumberLiteralContext ctx = ParseHelper.getPoeticNumberLiteral("My thing is a big bad monster");
         PoeticNumberLiteral a = new PoeticNumberLiteral(ctx);
-        assertEquals(1337, a.getValue());
-        assertEquals(int.class, a.getVariableClass());
+        assertEquals(1337d, a.getValue());
+        assertEquals(double.class, a.getVariableClass());
     }
 
     @Test
     public void shouldParsePoeticNumberLiteralsContainingZeros() {
         Rockstar.PoeticNumberLiteralContext ctx = ParseHelper.getPoeticNumberLiteral("Tommy was a lovestruck ladykiller");
         PoeticNumberLiteral a = new PoeticNumberLiteral(ctx);
-        assertEquals(100, a.getValue());
-        assertEquals(int.class, a.getVariableClass());
+        assertEquals(100d, a.getValue());
+        assertEquals(double.class, a.getVariableClass());
     }
 
     @Test
     public void shouldIgnoreCommas() {
         Rockstar.PoeticNumberLiteralContext ctx = ParseHelper.getPoeticNumberLiteral("My thing is a big, bad, monster");
         PoeticNumberLiteral a = new PoeticNumberLiteral(ctx);
-        assertEquals(1337, a.getValue());
-        assertEquals(int.class, a.getVariableClass());
+        assertEquals(1337d, a.getValue());
+        assertEquals(double.class, a.getVariableClass());
     }
 
     @Test
     public void shouldIgnoreApostrophes() {
         Rockstar.PoeticNumberLiteralContext ctx = ParseHelper.getPoeticNumberLiteral("My thing is a smokin' gun");
         PoeticNumberLiteral a = new PoeticNumberLiteral(ctx);
-        assertEquals(163, a.getValue());
-        assertEquals(int.class, a.getVariableClass());
+        assertEquals(163d, a.getValue());
+        assertEquals(double.class, a.getVariableClass());
     }
 
     @Test
     public void shouldIgnoreSemicolons() {
         Rockstar.PoeticNumberLiteralContext ctx = ParseHelper.getPoeticNumberLiteral("My thing is good; too good for you");
         PoeticNumberLiteral a = new PoeticNumberLiteral(ctx);
-        assertEquals(43433, a.getValue());
-        assertEquals(int.class, a.getVariableClass());
+        assertEquals(43433d, a.getValue());
+        assertEquals(double.class, a.getVariableClass());
     }
 
     @Test
@@ -73,8 +73,8 @@ public class PoeticNumberLiteralTest {
         Rockstar.PoeticNumberLiteralContext ctx = ParseHelper.getPoeticNumberLiteral(
                 "life is all-consuming");
         PoeticNumberLiteral a = new PoeticNumberLiteral(ctx);
-        assertEquals(3, a.getValue());
-        assertEquals(int.class, a.getVariableClass());
+        assertEquals(3d, a.getValue());
+        assertEquals(double.class, a.getVariableClass());
 
         ctx = ParseHelper.getPoeticNumberLiteral(
                 "life is all-consuming. death is a sweet rest.");

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/util/CapturingListener.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/util/CapturingListener.java
@@ -1,6 +1,5 @@
 package org.example.util;
 
-import org.antlr.v4.runtime.RuleContext;
 import rock.Rockstar;
 import rock.RockstarBaseListener;
 
@@ -9,7 +8,12 @@ import rock.RockstarBaseListener;
  */
 public class CapturingListener extends RockstarBaseListener {
     private Rockstar.AssignmentStmtContext assignmentStatement;
-    private RuleContext poeticNumberLiteral;
+    private Rockstar.PoeticNumberLiteralContext poeticNumberLiteral;
+    private Rockstar.ExpressionContext expression;
+    private Rockstar.LiteralContext literal;
+    private Rockstar.ConstantContext constant;
+
+    private Rockstar.VariableContext variable;
 
     @Override
     public void enterAssignmentStmt(Rockstar.AssignmentStmtContext assignmentStatement) {
@@ -21,12 +25,48 @@ public class CapturingListener extends RockstarBaseListener {
         this.poeticNumberLiteral = poeticNumberLiteral;
     }
 
+    @Override
+    public void enterLiteral(Rockstar.LiteralContext literal) {
+        this.literal = literal;
+    }
+
+    @Override
+    public void enterConstant(Rockstar.ConstantContext constant) {
+        this.constant = constant;
+    }
+
+    @Override
+    public void enterVariable(Rockstar.VariableContext variable) {
+        this.variable = variable;
+    }
+
+    @Override
+    public void enterExpression(Rockstar.ExpressionContext expression) {
+        this.expression = expression;
+    }
+
 
     public Rockstar.AssignmentStmtContext getAssignmentStatement() {
         return assignmentStatement;
     }
 
-    public RuleContext getPoeticNumberLiteral() {
+    public Rockstar.PoeticNumberLiteralContext getPoeticNumberLiteral() {
         return poeticNumberLiteral;
+    }
+
+    public Rockstar.ExpressionContext getExpression() {
+        return expression;
+    }
+
+    public Rockstar.LiteralContext getLiteral() {
+        return literal;
+    }
+
+    public Rockstar.ConstantContext getConstant() {
+        return constant;
+    }
+
+    public Rockstar.VariableContext getVariable() {
+        return variable;
     }
 }

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
@@ -27,6 +27,22 @@ public class ParseHelper {
         return (Rockstar.PoeticNumberLiteralContext) getGrammarElement(program, CapturingListener::getPoeticNumberLiteral);
     }
 
+    public static Rockstar.ExpressionContext getExpression(String program) {
+        return (Rockstar.ExpressionContext) getGrammarElement(program, CapturingListener::getExpression);
+    }
+
+    public static Rockstar.LiteralContext getLiteral(String program) {
+        return (Rockstar.LiteralContext) getGrammarElement(program, CapturingListener::getLiteral);
+    }
+
+    public static Rockstar.ConstantContext getConstant(String program) {
+        return (Rockstar.ConstantContext) getGrammarElement(program, CapturingListener::getConstant);
+    }
+
+    public static Rockstar.VariableContext getVariable(String program) {
+        return (Rockstar.VariableContext) getGrammarElement(program, CapturingListener::getVariable);
+    }
+
     private static RuleContext getGrammarElement(String program, Function<CapturingListener,
             RuleContext> getter) {
 /*
@@ -53,7 +69,7 @@ drive a parse to extract the thing we want.
 
             RuleContext answer = getter.apply(listener);
             if (answer == null) {
-                fail("There were no assignment statements. Did the program parse correctly?");
+                fail("There were no statements of the expected type. Did the program parse correctly?");
             }
             return answer;
         } catch (IOException e) {


### PR DESCRIPTION
The spec says   

> Number - Numbers in Rockstar are double-precision floating point numbers, stored according to the IEEE 754 standard.

I had to look it up, but https://stackoverflow.com/questions/40300041/is-there-any-ieee-754-standard-implementations-for-java-floating-point-primitive suggests that a java double should meet this nicely. 

Eliminating integer from the parsing logic simplifies the code nicely, but introduces an extra requirement; when printing round numbers, they should be printed as an integer, with no trailing “.0”. 

The `DecimalFormat` class is able to do that nicely, but we need to know if we’re dealing with a number to invoke it. That’s slightly more complex, especially since `ResultHandle` does not expose its type information. I had to do an ugly hack to get at it. 

Along the way, I pulled out some classes for structures like assignment and expression ... and that ended up being a rather large refactoring. It should make the codebase more scalable for further features, though.
