### PR TITLE
Support for negative number literals

### DIFF
--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
@@ -130,7 +130,7 @@ KW_NOR: N O R;
 PROPER_NOUN: [A-Z][A-Z|a-z]*;
 WORD: [a-z|A-Z]+;
 
-NUMERIC_LITERAL: [0-9]+ ('.' [0-9]+)?;
+NUMERIC_LITERAL: HYPHEN?[0-9]+ ('.' [0-9]+)?;
 STRING_LITERAL: '"' .*? '"';
 
 NL: [,. ]* '\r'? '\n';

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/LiteralTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/LiteralTest.java
@@ -31,6 +31,15 @@ public class LiteralTest {
     }
 
     @Test
+    public void shouldParseNegativeLiterals() {
+        Rockstar.LiteralContext ctx = ParseHelper.getLiteral("thing is -5");
+        Literal a = new Literal(ctx);
+        // The number should be stored as a double, even though it was entered as an integer
+        assertEquals(-5d, a.getValue());
+        assertEquals(double.class, a.getValueClass());
+    }
+
+    @Test
     public void shouldParseStringLiterals() {
         Rockstar.LiteralContext ctx = ParseHelper.getLiteral("thing is \"Yes hello\"");
         Literal a = new Literal(ctx);


### PR DESCRIPTION
The grammar couldn't parse negative numbers.