### PR TITLE
Allow whitespace at the beginning of statements

### DIFF
--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
@@ -6,7 +6,7 @@ program: (NL|WS)* (statementList | functionDeclaration)* WS*;
 
 statementList: statement+;
 
-statement: (ifStmt | inputStmt | outputStmt | assignmentStmt | incrementStmt | decrementStmt | loopStmt | returnStmt | continueStmt | breakStmt) (NL+?|EOF);
+statement: WS* (ifStmt | inputStmt | outputStmt | assignmentStmt | incrementStmt | decrementStmt | loopStmt | returnStmt | continueStmt | breakStmt) (NL+?|EOF);
 
 expression: functionCall
           | lhe=expression WS op=(KW_MULTIPLY|KW_DIVIDE) WS rhe=expression

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -119,6 +119,20 @@ names in Rockstar.)
         assertEquals("28\n28\n28\n", output);
     }
 
+    @Test
+    public void shouldNotBeSensitiveToWhitespace() {
+        String program = """
+                Time is an illusion
+                  Shout time
+                    Shout time
+                Shout time          
+                Shout time
+                                            """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("28\n28\n28\n28\n", output);
+    }
+
     /*
  Common variables consist of one of the keywords a , an , the , my , your or our followed by whitespace and a unique variable name,
  which must contain only lowercase ASCII letters a-z. The keyword is part of the variable name, so a boy is a different variable from


### PR DESCRIPTION
Resolves #16 

I also included trailing whitespace in the tests, and that seems to be tolerated without grammar changes.