### PR TITLE
Add support for conditionals and comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Some of these may work but have not been validated with tests.
 
 ## Single quotes
 
-- [ ] Equivalency to `is'
-- [ ] Ignoring in other cases
+- [X] Equivalency to `is'
+- [X] Ignoring in other cases
 
 ## Number operations
 
@@ -109,7 +109,7 @@ Some of these may work but have not been validated with tests.
 ## Comparison and logical operations
 
 - [ ] Assignment using comparison
-- [ ] Equality tests
+- [X] Equality tests
 - [ ] Conjunction
 - [ ] Disjunction
 - [ ] Joint denial
@@ -122,7 +122,7 @@ Some of these may work but have not been validated with tests.
 
 ## Flow control
 
-- [ ] Conditionals
+- [X] Conditionals
 - [ ] Loops
 - [ ] Blocks
 - [ ] Functions

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
@@ -14,6 +14,7 @@ expression: functionCall
           | lhe=expression WS op=(PLUS_SIGN|HYPHEN) WS rhe=expression
           | lhe=expression WS op=(ASTERISK|SLASH) WS rhe=expression
           | lhe=expression WS comparisionOp WS rhe=expression
+          | lhe=expression contractedComparisionOp WS rhe=expression
           | lhe=expression WS op=(KW_AND|KW_OR|KW_NOR) WS rhe=expression
           | (literal|variable|constant)
 ;
@@ -26,23 +27,25 @@ functionDeclaration: functionName=variable WS KW_TAKES WS paramList NL statement
 
 paramList: variable ((COMMA? WS KW_AND WS | COMMA | AMPERSAND | APOSTROPHED_N) variable)*;
 
-comparisionOp: KW_IS
-             | KW_NOT_EQUAL
-             | KW_IS WS (KW_GREATER|KW_LESS) WS KW_THAN
-             | KW_IS WS KW_AS WS (KW_GREATER_EQUAL|KW_LESS_EQUAL) WS KW_AS
-;
-
 assignmentStmt: variable (APOSTROPHE_S | APOSTROPHE_RE | WS (KW_IS|KW_WAS_WERE)) WS (poeticNumberLiteral|constant|literal)
               | KW_LET WS variable WS KW_BE WS expression
               | KW_PUT WS expression WS KW_INTO WS variable
               | variable WS (KW_SAYS | KW_SAY) WS poeticStringLiteral
 ;
 
+comparisionOp: KW_IS
+             | KW_NOT_EQUAL
+             | KW_IS WS (KW_GREATER|KW_LESS) WS KW_THAN
+             | KW_IS WS KW_AS WS (KW_GREATER_EQUAL|KW_LESS_EQUAL) WS KW_AS
+;
+
+contractedComparisionOp: APOSTROPHE_S;
+
 inputStmt: KW_LISTEN WS KW_TO WS variable;
 
 outputStmt: (KW_SHOUT | KW_SAY) WS expression;
 
-ifStmt: KW_IF WS expr=expression NL statementList (KW_ELSE NL statementList)?;
+ifStmt: KW_IF WS expr=expression NL statementList  (WS* KW_ELSE NL? statementList)?;
 
 loopStmt: KW_LOOP WS expr=expression NL statementList;
 

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
@@ -1,8 +1,8 @@
 package org.example;
 
+import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
 import org.example.grammar.PoeticNumberLiteral;
 import rock.Rockstar;
@@ -69,7 +69,7 @@ public class Assignment {
         return variableClass;
     }
 
-    public void toCode(ClassCreator creator, MethodCreator method) {
+    public void toCode(ClassCreator creator, BytecodeCreator method) {
 
         FieldDescriptor field = variable.getField(creator, method, getVariableClass());
 

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Checker.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Checker.java
@@ -1,0 +1,8 @@
+package org.example;
+
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.ResultHandle;
+
+public interface Checker {
+    BranchResult doCheck(ResultHandle equalityCheck);
+}

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Condition.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Condition.java
@@ -1,0 +1,26 @@
+package org.example;
+
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ResultHandle;
+import rock.Rockstar;
+
+public class Condition {
+    private final boolean hasElse;
+    Expression expression;
+
+    public Condition(Rockstar.IfStmtContext ctx) {
+        expression = new Expression(ctx.expression());
+        hasElse = ctx.KW_ELSE() != null;
+    }
+
+    public BranchResult toCode(BytecodeCreator main) {
+        ResultHandle evaluated = expression.getResultHandle(main);
+        BranchResult conditional = main.ifTrue(evaluated);
+        return conditional;
+    }
+
+    public boolean hasElse() {
+        return hasElse;
+    }
+}

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Expression.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Expression.java
@@ -1,6 +1,9 @@
 package org.example;
 
-import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import rock.Rockstar;
@@ -15,7 +18,10 @@ public class Expression {
     private Expression rhe;
     private Operation operation;
 
-    private enum Operation {ADD, SUBTRACT, MULTIPLY, DIVIDE}
+    private enum Operation {
+        ADD, SUBTRACT, MULTIPLY, EQUALITY_CHECK, INEQUALITY_CHECK, GREATER_THAN_CHECK,
+        LESS_THAN_CHECK, GREATER_OR_EQUAL_THAN_CHECK, LESS_OR_EQUAL_THAN_CHECK, DIVIDE
+    }
 
 
     public Expression(Rockstar.ExpressionContext ctx) {
@@ -24,7 +30,38 @@ public class Expression {
             Rockstar.ConstantContext constant = ctx.constant();
             Rockstar.VariableContext variableContext = ctx.variable();
 
-            if (ctx.op != null) {
+            if (ctx.comparisionOp() != null) {
+                Rockstar.ComparisionOpContext cop = ctx.comparisionOp();
+                lhe = new Expression(ctx.lhe);
+                rhe = new Expression(ctx.rhe);
+
+                if (cop.KW_LESS() != null) {
+                    operation = Operation.LESS_THAN_CHECK;
+                } else if (cop.KW_GREATER() != null) {
+                    operation = Operation.GREATER_THAN_CHECK;
+                } else if (cop.KW_LESS_EQUAL() != null) {
+                    operation = Operation.LESS_OR_EQUAL_THAN_CHECK;
+                } else if (cop.KW_GREATER_EQUAL() != null) {
+                    operation = Operation.GREATER_OR_EQUAL_THAN_CHECK;
+                } else if (cop.KW_NOT_EQUAL() != null) {
+                    operation = Operation.INEQUALITY_CHECK;
+                } else if (cop.KW_IS() != null) {
+                    // Do this check last since many other comparisons include an equality check
+                    operation = Operation.EQUALITY_CHECK;
+                }
+
+            } else if (ctx.contractedComparisionOp() != null) {
+                Rockstar.ContractedComparisionOpContext cop = ctx.contractedComparisionOp();
+                lhe = new Expression(ctx.lhe);
+                rhe = new Expression(ctx.rhe);
+
+                if (cop.APOSTROPHE_S() != null) {
+                    operation = Operation.EQUALITY_CHECK;
+                } else {
+                    throw new RuntimeException("Unknown contracted comparison operation: " + cop.getText());
+                }
+
+            } else if (ctx.op != null) {
                 lhe = new Expression(ctx.lhe);
                 rhe = new Expression(ctx.rhe);
 
@@ -38,10 +75,11 @@ public class Expression {
                     operation = Operation.DIVIDE;
                 }
             }
+            System.out.println("operastion is " + operation);
 
             if (literal != null) {
                 if (literal
-                        .NUMERIC_LITERAL() != null) {
+                            .NUMERIC_LITERAL() != null) {
 
                     TerminalNode num = literal
                             .NUMERIC_LITERAL();
@@ -52,7 +90,7 @@ public class Expression {
                     valueClass = double.class;
 
                 } else if (literal
-                        .STRING_LITERAL() != null) {
+                                   .STRING_LITERAL() != null) {
                     value = literal
                             .STRING_LITERAL()
                             .getText()
@@ -63,16 +101,13 @@ public class Expression {
                 }
 
             } else if (constant != null) {
-                if (constant
-                        .CONSTANT_TRUE() != null) {
+                if (constant.CONSTANT_TRUE() != null) {
                     value = true;
                     valueClass = boolean.class;
-                } else if (constant
-                        .CONSTANT_FALSE() != null) {
+                } else if (constant.CONSTANT_FALSE() != null) {
                     value = false;
                     valueClass = boolean.class;
-                } else if (constant
-                        .CONSTANT_EMPTY() != null) {
+                } else if (constant.CONSTANT_EMPTY() != null) {
                     value = "";
                     valueClass = String.class;
                 }
@@ -97,20 +132,58 @@ public class Expression {
         return valueClass;
     }
 
-    public ResultHandle getResultHandle(MethodCreator method) {
+    public ResultHandle getResultHandle(BytecodeCreator method) {
         if (operation != null) {
-            if (operation == Operation.ADD) {
-                return method.add(lhe.getResultHandle(method), rhe.getResultHandle(method));
-            } else if (operation == Operation.SUBTRACT) {
-                // Handle subtraction by multiplying by -1 and adding
-                ResultHandle negativeRightSide = method.multiply(method.load(-1d), rhe.getResultHandle(method));
-                return method.add(lhe.getResultHandle(method), negativeRightSide);
-            } else if (operation == Operation.MULTIPLY) {
-                return method.multiply(lhe.getResultHandle(method), rhe.getResultHandle(method));
-            } else if (operation == Operation.DIVIDE) {
-                //  return method.divide(lhe.getResultHandle(method), rhe.getResultHandle(method));
-                throw new RuntimeException("Unsupported operation: divided we fall, and all that");
+            ResultHandle lrh = lhe.getResultHandle(method);
+            ResultHandle rrh = rhe.getResultHandle(method);
+
+            switch (operation) {
+                case ADD -> {
+                    return method.add(lrh, rrh);
+                }
+                case SUBTRACT -> {
+                    // Handle subtraction by multiplying by -1 and adding
+                    ResultHandle negativeRightSide = method.multiply(method.load(-1d), rrh);
+                    return method.add(lrh, negativeRightSide);
+                }
+                case MULTIPLY -> {
+                    return method.multiply(lrh, rrh);
+                }
+                case DIVIDE -> {
+                    //  return method.divide(lhe.getResultHandle(method), rhe.getResultHandle(method));
+                    throw new RuntimeException("Unsupported operation: divided we fall, and all that");
+                }
+                case EQUALITY_CHECK -> {
+                    return method.invokeVirtualMethod(MethodDescriptor.ofMethod("java/lang/Object", "equals", "Z", "Ljava/lang/Object;"),
+                            lrh, rrh);
+                }
+                case INEQUALITY_CHECK -> {
+                    // A boolean negation in bytecode is a bit tricky, since the jvm doesn't really recognise booleans, so do a bitwise xor
+                    // to simulate it
+                    ResultHandle equalityCheck = method.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod("java/lang/Object", "equals", "Z", "Ljava/lang/Object;"),
+                            lrh, rrh);
+                    return method.bitwiseXor(equalityCheck, method.load(true));
+                }
+                case GREATER_THAN_CHECK -> {
+                    return doComparison(method, (ResultHandle eq) -> method.ifGreaterThanZero(eq),
+                            lrh, rrh);
+                }
+                case LESS_THAN_CHECK -> {
+                    return doComparison(method, (ResultHandle eq) -> method.ifLessThanZero(eq),
+                            lrh, rrh);
+                }
+                case GREATER_OR_EQUAL_THAN_CHECK -> {
+                    return doComparison(method, (ResultHandle eq) -> method.ifGreaterEqualZero(eq),
+                            lrh, rrh);
+                }
+                case LESS_OR_EQUAL_THAN_CHECK -> {
+                    return doComparison(method, (ResultHandle eq) -> method.ifLessEqualZero(eq),
+                            lrh, rrh);
+                }
+                default -> throw new RuntimeException("Unsupported operation " + operation);
             }
+
         } else if (variable != null) {
             return variable.read(method);
         } else {
@@ -124,5 +197,19 @@ public class Expression {
             }
         }
         throw new RuntimeException("Could not interpret type " + valueClass);
+    }
+
+    private static AssignableResultHandle doComparison(BytecodeCreator method, Checker comparison,
+                                                       ResultHandle lrh, ResultHandle rrh) {
+        ResultHandle equalityCheck = method.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod("java/lang/Comparable", "compareTo", "I", "Ljava/lang/Object;"),
+                lrh, rrh);
+        BranchResult result = comparison.doCheck(equalityCheck);
+        AssignableResultHandle answer = method.createVariable("Z");
+        BytecodeCreator trueBranch = result.trueBranch();
+        trueBranch.assign(answer, method.load(true));
+        result.falseBranch()
+              .assign(answer, method.load(false));
+        return answer;
     }
 }

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
@@ -1,8 +1,8 @@
 package org.example;
 
+import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.objectweb.asm.Opcodes;
@@ -68,7 +68,7 @@ public class Variable {
     }
 
 
-    public ResultHandle read(MethodCreator method) {
+    public ResultHandle read(BytecodeCreator method) {
         if (variables.containsKey(variableName)) {
             return method.readStaticField(variables.get(variableName));
 
@@ -78,7 +78,8 @@ public class Variable {
         }
     }
 
-    public void write(MethodCreator method, ResultHandle value) {
+    public void write(BytecodeCreator method, ResultHandle value) {
+
         FieldDescriptor field = variables.get(variableName);
 
         method.writeStaticField(field, value);
@@ -86,9 +87,8 @@ public class Variable {
 
     // TODO if we use local variables we can drop passing the class creator
     // TODO would it be nicer to store our own class?
-    public FieldDescriptor getField(ClassCreator creator, MethodCreator method, Class<?> clazz) {
+    public FieldDescriptor getField(ClassCreator creator, BytecodeCreator method, Class<?> clazz) {
         FieldDescriptor field;
-
         if (!variables.containsKey(variableName)) {
 
             String javaCompliantName = getNormalisedVariableName();

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -533,6 +533,87 @@ names in Rockstar.)
         assertEquals("4\n", output);
     }
 
+    @Test
+    public void shouldHandleComparisons() {
+        String program = """
+                Say 1 is 2
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("false\n", output);
+    }
+
+    @Test
+    public void shouldHandleConditionalsForTrueCase() {
+        // Positive case
+        String program = """
+                Tommy is a big bad monster
+                If Tommy is 1337
+                Say "he is bad"
+                Say "end line"
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("he is bad\nend line\n", output);
+    }
+
+    @Test
+    public void shouldHandleConditionalsForAintCheck() {
+        // Positive case
+        String program = """
+                Tommy is a big bad monster
+                If Tommy ain't 1337
+                Say "main case"
+                Else 
+                Say "else case"
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("else case\n", output);
+    }
+
+    @Test
+    public void shouldHandleConditionalsForFalseCase() {
+        // Negative case
+        String program = """
+                 Tommy is a big bad monster
+                 If Tommy is 133333373737777
+                 Say "he is very bad"
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("", output);
+    }
+
+
+    @Test
+    public void shouldHandleIfElseConditionalsForTrueBranch() {
+        String program = """
+                Tommy is a big bad monster
+                If Tommy is 1337
+                Say "he is bad"
+                Else
+                Say "he is good"
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("he is bad\n", output);
+    }
+
+    @Test
+    public void shouldHandleIfElseConditionalsForFalseBranch() {
+        String program = """
+                Tommy is a big bad monster
+                If Tommy is 13337737373337
+                Say "this is the true branch"
+                Else
+                Say "this is the false branch"
+                """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("this is the false branch\n", output);
+    }
+
     private String compileAndLaunch(String program) {
         // Save the current System.out for later restoration
         PrintStream originalOut = System.out;

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/ConditionTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/ConditionTest.java
@@ -1,0 +1,41 @@
+package org.example;
+
+import org.example.util.ParseHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import rock.Rockstar;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+Note that even though we're just testing the expressions, they need to be couched in something like output statement to be
+recognised.
+ */
+public class ConditionTest {
+
+    @BeforeEach
+    public void clearState() {
+        Variable.clearPronouns();
+    }
+
+    // We can't execute a condition in isolation (we get verification errors) so the tests here are pretty trivial
+   
+    @Test
+    public void shouldDetectElse() {
+        Rockstar.IfStmtContext ctx = ParseHelper.getIf("""                
+                If true is right
+                Say "he is ok"
+                Else say "no way"
+                """);
+        Condition condition = new Condition(ctx);
+        assertTrue(condition.hasElse());
+
+        ctx = ParseHelper.getIf("""                
+                If true is right
+                Say "he is ok"
+                """);
+        condition = new Condition(ctx);
+        assertFalse(condition.hasElse());
+    }
+}

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
@@ -14,7 +14,9 @@ import rock.Rockstar;
 import java.lang.reflect.InvocationTargetException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
@@ -227,6 +229,216 @@ empty , silent , and silence are aliases for the empty string ( "" ).
         a = new Expression(ctx);
         answer = (double) execute(a);
         assertEquals(5d, answer);
+    }
+
+    @Test
+    public void shouldHandleComparisonOfNumbers() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 1 is 2", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("shout 1 is 1", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldHandleComparisonOfBooleans() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say ok is right", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("shout right is wrong", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldHandleComparisonOfStrings() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say \"life\" is \"life\"", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say \"live\" is \"life\"", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+    }
+
+    @Disabled("This also fails to parse in the reference implementation")
+    @Test
+    public void shouldHandleAintComparisonOfStrings() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 123 ain’t \"nobody\"", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say \"Tommy\" ain’t \"Tommy\"", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldHandleAintComparisonOfStringsWithNoApostrophe() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say \"Tommy\" aint \"nobody\"", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say \"Tommy\" aint \"Tommy\"", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldHandleContractionSComparison() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 123's 123", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 123's 124", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldHandleGreaterThanComparison() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 5 is greater than 10", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 2 is stronger than 20", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 20 is stronger than 2", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 20 is higher than 2", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 20 is bigger than 2", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldReturnFalseForGreaterThanComparisonOfEqualThings() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 5 is greater than 5", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldHandleGreaterThanOrEqualComparison() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 5 is as great as 10", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 2 is as strong as 20", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 20 is as strong as 2", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 20 is as high as 2", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 20 is as big as 2", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        // Equality cases
+
+        ctx = ParseHelper.getExpression("say 5 is as great as 5", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 2 is as strong as 2", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 6 is as high as 6", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 7 is as big as 7", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldHandleLessThanComparison() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 15 is less than 10", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 22 is lower than 20", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 2 is weaker than 22", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 20 is smaller than 22", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldReturnFalseForLessThanComparisonOfEqualThings() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 5 is less than 5", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldHandleLessThanOrEqualComparison() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 15 is as low as 10", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 22 is as little as 20", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 2 is as weak as 22", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 20 is as small as 22", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        // Equality cases
+        ctx = ParseHelper.getExpression("say 15 is as low as 15", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 22 is as little as 22", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 2 is as weak as 2", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 3 is as small as 3", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+
+    /*
+   "02" < "10" is true because the lexicographical comparison between 0 and 1 shows that the first string is less than the second string.
+     */
+    @Test
+    public void shouldHandleLexographicalComparison() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say \"02\" is less than \"10\"", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say \"02\" is greater than \"10\"", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+    }
+
+    /* "1" is 1 evaluates to true because "1" gets converted to the number 1 */
+    @Disabled("Needs casting support")
+    @Test
+    public void shouldHandleCastingInComparison() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say \"1\" is 1", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+    /**
+     * True < 10 is an error because 10 gets coerced into True due to the comparison with a boolean and there are no allowed
+     * ordering comparisons between booleans.
+     */
+    @Test
+    public void shouldNotAllowComparisonBetweenBooleanAndNumbers() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say true is less than 10", 0);
+        assertThrows(Throwable.class, () -> execute(new Expression(ctx)));
+    }
+
+    /*    "2" ain't Mysterious evaluates to true because all types are non equal to mysterious, besides mysterious itself.
+     */
+    @Disabled("Mysterious support")
+    @Test
+    public void shouldFindAnythingExceptMysteriousIsNotMysterious() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say \"2\" ain't Mysterious", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+    /*
+   all types are non equal to mysterious, besides mysterious itself
+     */
+    @Disabled("Mysterious support")
+    @Test
+    public void shouldHaveMysteriousEqualToItself() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say mysterious ain't Mysterious", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
     }
 
     @Test

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/util/CapturingListener.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/util/CapturingListener.java
@@ -1,5 +1,6 @@
 package org.example.util;
 
+import org.antlr.v4.runtime.RuleContext;
 import rock.Rockstar;
 import rock.RockstarBaseListener;
 
@@ -15,8 +16,8 @@ public class CapturingListener extends RockstarBaseListener {
     private List<Rockstar.ExpressionContext> expressions = new ArrayList<>();
     private Rockstar.LiteralContext literal;
     private Rockstar.ConstantContext constant;
-
     private Rockstar.VariableContext variable;
+    private Rockstar.IfStmtContext ifCondition;
 
     @Override
     public void enterAssignmentStmt(Rockstar.AssignmentStmtContext assignmentStatement) {
@@ -48,6 +49,10 @@ public class CapturingListener extends RockstarBaseListener {
         this.expressions.add(expression);
     }
 
+    @Override
+    public void enterIfStmt(Rockstar.IfStmtContext ifCondition) {
+        this.ifCondition = ifCondition;
+    }
 
     public Rockstar.AssignmentStmtContext getAssignmentStatement() {
         return assignmentStatement;
@@ -75,5 +80,9 @@ public class CapturingListener extends RockstarBaseListener {
 
     public Rockstar.VariableContext getVariable() {
         return variable;
+    }
+
+    public RuleContext getIf() {
+        return ifCondition;
     }
 }

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
@@ -47,6 +47,10 @@ public class ParseHelper {
         return (Rockstar.VariableContext) getGrammarElement(program, CapturingListener::getVariable);
     }
 
+    public static Rockstar.IfStmtContext getIf(String program) {
+        return (Rockstar.IfStmtContext) getGrammarElement(program, CapturingListener::getIf);
+    }
+    
     private static RuleContext getGrammarElement(String program, Function<CapturingListener,
             RuleContext> getter) {
 /*


### PR DESCRIPTION
From the spec:

> Conditionals
> Conditional expressions start with the If keyword, followed by an expression. If the expression evaluates to true, then the subsequent code block is executed. Optionally, an Else block can be written after an If block. The code block following the Else keyword would be executed if the If expression evaluated to false.
For the purpose of conditional expressions, 0, mysterious, null, false, and the empty string all evaluate to false, and everything else to true.

In order to meaningfully implement conditionals, I also had to implement comparisons. Doing comparison operators in bytecode was a bit harder than I expected. I drew inspiration from https://stackoverflow.com/questions/60137736/implementing-comparison-operators-in-bytecode-using-asm and ended up implementing them as an 'if'. I'm not sure if the bytecode is as good as it could be, but we can refine if it bothers us, with the support of the tests.  