### PR TITLE
Add support for while and until loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Some of these may work but have not been validated with tests.
 
 - [ ] Assignment using comparison
 - [X] Equality tests
+- [ ] Comparisons to mysterious and null
 - [ ] Conjunction
 - [ ] Disjunction
 - [ ] Joint denial
@@ -123,7 +124,7 @@ Some of these may work but have not been validated with tests.
 ## Flow control
 
 - [X] Conditionals
-- [ ] Loops
-- [ ] Blocks
+- [X] Loops
+- [ ] Blocks, break, and continue
 - [ ] Functions
 

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
@@ -47,7 +47,7 @@ outputStmt: (KW_SHOUT | KW_SAY) WS expression;
 
 ifStmt: KW_IF WS expr=expression NL statementList  (WS* KW_ELSE NL? statementList)?;
 
-loopStmt: KW_LOOP WS expr=expression NL statementList;
+loopStmt: (KW_WHILE | KW_UNTIL) WS expr=expression NL statementList;
 
 incrementStmt: KW_BUILD WS variable WS ups;
 
@@ -130,7 +130,8 @@ allKeywords: KW_PUT
            | KW_TO
            | KW_SAY
            | KW_SHOUT
-           | KW_LOOP
+           | KW_WHILE
+           | KW_UNTIL
            | KW_IF
            | KW_ELSE
            | KW_BUILD

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
@@ -88,7 +88,8 @@ KW_LISTEN: L I S T E N;
 KW_TO: T O ;
 KW_SHOUT:  S H O U T | W H I S P E R | S C R E A M;
 
-KW_LOOP: W H I L E | U N T I L;
+KW_WHILE: W H I L E ;
+KW_UNTIL: U N T I L;
 KW_IF: I F;
 KW_ELSE: E L S E;
 

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Expression.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Expression.java
@@ -195,7 +195,7 @@ public class Expression {
                 return method.load((boolean) value);
             }
         }
-        throw new RuntimeException("Could not interpret type " + valueClass);
+        throw new RuntimeException("Confused expression: Could not interpret type " + valueClass);
     }
 
     private static AssignableResultHandle doComparison(BytecodeCreator method, Checker comparison,

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -122,7 +122,7 @@ names in Rockstar.)
     @Test
     public void shouldUseApostrophesForAssignmentAndIgnoreOtherApostrophes() {
         String program = """
-                The fire's burning Tommy's feet     
+                The fire's burning Tommy's feet 
                 Shout the fire
                                             """;
         String output = compileAndLaunch(program);
@@ -564,7 +564,7 @@ names in Rockstar.)
                 Tommy is a big bad monster
                 If Tommy ain't 1337
                 Say "main case"
-                Else 
+                Else
                 Say "else case"
                 """;
         String output = compileAndLaunch(program);
@@ -612,6 +612,40 @@ names in Rockstar.)
         String output = compileAndLaunch(program);
 
         assertEquals("this is the false branch\n", output);
+    }
+
+    @Test
+    public void shouldHandleWhileLoops() {
+        // Positive case
+        String program = """
+                Tommy was a dancer
+                While Tommy ain't 0,
+                Knock Tommy down
+                Say Tommy
+                """;
+        String output = compileAndLaunch(program);
+
+        // TODO Ain't nothing should also work, but does not
+
+        // TODO This should be a full number list, but that will not work until block support is implemented
+        assertEquals("0\n", output);
+    }
+
+    @Test
+    public void shouldHandleUntilLoops() {
+        // Positive case
+        String program = """
+                Tommy was a dancer
+                Until Tommy is 0,
+                Knock Tommy down
+                Say Tommy
+                """;
+        String output = compileAndLaunch(program);
+
+        // TODO Is nothing should also work, but does not
+
+        // TODO This should be a full number list, but that will not work until block support is implemented
+        assertEquals("0\n", output);
     }
 
     private String compileAndLaunch(String program) {


### PR DESCRIPTION
> ### Loops
> Similar to the If statement, a loop is denoted by the While or Until keyword, which will cause the subsequent code block to be executed repeatedly whilst the expression is satisfied:
> ```
> Tommy was a dancer
> While Tommy ain't nothing,
> Knock Tommy down
> ```
> That’ll initialize Tommy with the value 16 (using the poetic number literal syntax) and then loop, decrementing Tommy by 1 each time until Tommy equals zero (i.e ain't nothing returns false).

### Limitations

- Pending proper block support, only the first line in the loop is included in the execution. 
- Pending block support, `break` and `continue` are not supported. 
- A comparison like 'ain't nothing' is not possible yet, so it has to be 'ain't 0'