### PR TITLE
Improved support for mysterious and nothing, including comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Some of these may work but have not been validated with tests.
 - [X] String literals
 - [X] Poetic string literals
 
-## Types
+## ✓ Types
 
-- [ ] Mysterious
-- [ ] Null equality to 0 and false
+- [X] Mysterious
+- [X] Null equality to 0 and false
 - [X] Null aliases `nothing`, `nowhere`, `nobody`, `gone`
 - [X] True aliases `right`, `yes`, `ok`
 - [X] False aliases `wrong`, `no`, `lies`
@@ -108,9 +108,9 @@ Some of these may work but have not been validated with tests.
 
 ## Comparison and logical operations
 
-- [ ] Assignment using comparison
+- [ ] Assignment using comparison and other operators
 - [X] Equality tests
-- [ ] Comparisons to mysterious and null
+- [X] Comparisons to mysterious and null
 - [ ] Conjunction
 - [ ] Disjunction
 - [ ] Joint denial

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
@@ -248,4 +248,29 @@ public class BytecodeGeneratingListener extends RockstarBaseListener {
         return value.toString()
                     .contains("type='D'");
     }
+
+    public static boolean isBoolean(ResultHandle value) {
+        // ResultHandle knows the type, but it's private
+        // Doing an instanceof check on a primitive tends to blow up, and it clutters the output code, so cheat
+        // Take advantage of the toString format of ResultHandle
+        return value.toString()
+                    .contains("type='Z'");
+    }
+
+    public static boolean isString(ResultHandle value) {
+        // ResultHandle knows the type, but it's private
+        // Doing an instanceof check on a primitive tends to blow up, and it clutters the output code, so cheat
+        // Take advantage of the toString format of ResultHandle
+        return value.toString()
+                    .contains("type='Ljava/lang/String;'");
+    }
+
+    public static boolean isNull(ResultHandle value) {
+        // ResultHandle knows the type, but it's private
+        // Doing an instanceof check on a primitive tends to blow up, and it clutters the output code, so cheat
+        // Take advantage of the toString format of ResultHandle
+        return value.toString()
+                    .contains("owner=null");
+    }
+
 }

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Constant.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Constant.java
@@ -1,8 +1,17 @@
 package org.example;
 
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ResultHandle;
 import rock.Rockstar;
 
+import static org.example.BytecodeGeneratingListener.isBoolean;
+import static org.example.BytecodeGeneratingListener.isNumber;
+import static org.example.BytecodeGeneratingListener.isString;
+
 public class Constant {
+
+    public static final Nothing NOTHING = new Nothing();
+
     private Class<?> valueClass;
     private Object value;
 
@@ -10,17 +19,24 @@ public class Constant {
 
         if (constant != null) {
             if (constant
-                    .CONSTANT_TRUE() != null) {
+                        .CONSTANT_TRUE() != null) {
                 value = true;
                 valueClass = boolean.class;
             } else if (constant
-                    .CONSTANT_FALSE() != null) {
+                               .CONSTANT_FALSE() != null) {
                 value = false;
                 valueClass = boolean.class;
             } else if (constant
-                    .CONSTANT_EMPTY() != null) {
+                               .CONSTANT_EMPTY() != null) {
                 value = "";
                 valueClass = String.class;
+            } else if (constant
+                               .CONSTANT_NULL() != null) {
+                value = NOTHING;
+                valueClass = Nothing.class;
+            } else if (constant.CONSTANT_UNDEFINED() != null) {
+                value = null;
+                valueClass = null;
             }
         }
     }
@@ -32,5 +48,17 @@ public class Constant {
 
     public Class<?> getValueClass() {
         return valueClass;
+    }
+
+    public static ResultHandle coerceNothingIntoType(BytecodeCreator method, ResultHandle referenceHandle) {
+        if (isNumber(referenceHandle)) {
+            return method.load(0d);
+        } else if (isBoolean(referenceHandle)) {
+            return method.load(false);
+        } else if (isString(referenceHandle)) {
+            return method.load("");
+        } else {
+            return method.loadNull();
+        }
     }
 }

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Literal.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Literal.java
@@ -8,10 +8,8 @@ public class Literal {
     private Object value;
 
     public Literal(Rockstar.LiteralContext literal) {
-
         if (literal != null) {
-            if (literal
-                    .NUMERIC_LITERAL() != null) {
+            if (literal.NUMERIC_LITERAL() != null) {
 
                 TerminalNode num = literal
                         .NUMERIC_LITERAL();
@@ -21,8 +19,7 @@ public class Literal {
 
                 valueClass = double.class;
 
-            } else if (literal
-                    .STRING_LITERAL() != null) {
+            } else if (literal.STRING_LITERAL() != null) {
                 value = literal
                         .STRING_LITERAL()
                         .getText()

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Nothing.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Nothing.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class Nothing {
+}

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/AssignmentTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/AssignmentTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import rock.Rockstar;
 
+import static org.example.Constant.NOTHING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -157,34 +158,37 @@ public class AssignmentTest {
     }
 
     /*
-    Rockstar makes a distinction between `null` and `undefined`. Javascript also does this,
-    but since Java does not, we will ignore that for the moment.
+    Rockstar makes a distinction between `null` and `undefined`. The undefined is closer to Java's null.
      */
     @Test
     public void shouldParseUndefinedConstants() {
         Rockstar.AssignmentStmtContext ctx = ParseHelper.getAssignment("My thing is mysterious");
         Assignment a = new Assignment(ctx);
         assertNull(a.getValue());
-        // Not great, but the best we can do
     }
 
+    /*
+ Rockstar makes a distinction between `null` and `undefined`. The null class is equal to 0 and false, so it can't be represented by a
+ Java null.
+  */
     @Test
     public void shouldParseNullConstants() {
         Rockstar.AssignmentStmtContext ctx = ParseHelper.getAssignment("My thing is nothing");
         Assignment a = new Assignment(ctx);
-        assertNull(a.getValue());
+        assertEquals(Nothing.class, a.getVariableClass());
+        assertEquals(NOTHING, a.getValue());
 
         ctx = ParseHelper.getAssignment("My thing is nobody");
-        a = new Assignment(ctx);
-        assertNull(a.getValue());
+        assertEquals(Nothing.class, a.getVariableClass());
+        assertEquals(NOTHING, a.getValue());
 
         ctx = ParseHelper.getAssignment("My thing is nowhere");
-        a = new Assignment(ctx);
-        assertNull(a.getValue());
+        assertEquals(Nothing.class, a.getVariableClass());
+        assertEquals(NOTHING, a.getValue());
 
         ctx = ParseHelper.getAssignment("My thing is gone");
-        a = new Assignment(ctx);
-        assertNull(a.getValue());
+        assertEquals(Nothing.class, a.getVariableClass());
+        assertEquals(NOTHING, a.getValue());
     }
 
     @Test

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -652,8 +652,6 @@ names in Rockstar.)
                 """;
         String output = compileAndLaunch(program);
 
-        // TODO Ain't nothing should also work, but does not
-
         String expected = """
                 2
                 1
@@ -671,8 +669,6 @@ names in Rockstar.)
                 Say Tommy
                 """;
         String output = compileAndLaunch(program);
-
-        // TODO Is nothing should also work, but does not
 
         String expected = """
                 3

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/ConstantTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/ConstantTest.java
@@ -4,6 +4,7 @@ import org.example.util.ParseHelper;
 import org.junit.jupiter.api.Test;
 import rock.Rockstar;
 
+import static org.example.Constant.NOTHING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -79,26 +80,25 @@ public class ConstantTest {
         Rockstar.ConstantContext ctx = ParseHelper.getConstant("life is mysterious");
         Constant a = new Constant(ctx);
         assertNull(a.getValue());
-        // Not great, but the best we can do
     }
 
     @Test
     public void shouldParseNullConstants() {
         Rockstar.ConstantContext ctx = ParseHelper.getConstant("life is nothing");
         Constant a = new Constant(ctx);
-        assertNull(a.getValue());
+        assertEquals(NOTHING, a.getValue());
 
         ctx = ParseHelper.getConstant("life is nobody");
         a = new Constant(ctx);
-        assertNull(a.getValue());
+        assertEquals(NOTHING, a.getValue());
 
         ctx = ParseHelper.getConstant("life is nowhere");
         a = new Constant(ctx);
-        assertNull(a.getValue());
+        assertEquals(NOTHING, a.getValue());
 
         ctx = ParseHelper.getConstant("life is gone");
         a = new Constant(ctx);
-        assertNull(a.getValue());
+        assertEquals(NOTHING, a.getValue());
     }
 
 }

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
@@ -13,6 +13,7 @@ import rock.Rockstar;
 
 import java.lang.reflect.InvocationTargetException;
 
+import static org.example.Constant.NOTHING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -122,19 +123,19 @@ empty , silent , and silence are aliases for the empty string ( "" ).
     public void shouldParseNullConstants() {
         Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout nothing");
         Expression a = new Expression(ctx);
-        assertNull(a.getValue());
+        assertEquals(NOTHING, a.getValue());
 
         ctx = ParseHelper.getExpression("shout nobody");
         a = new Expression(ctx);
-        assertNull(a.getValue());
+        assertEquals(NOTHING, a.getValue());
 
         ctx = ParseHelper.getExpression("shout nowhere");
         a = new Expression(ctx);
-        assertNull(a.getValue());
+        assertEquals(NOTHING, a.getValue());
 
         ctx = ParseHelper.getExpression("shout gone");
         a = new Expression(ctx);
-        assertNull(a.getValue());
+        assertEquals(NOTHING, a.getValue());
     }
 
     @Test
@@ -269,7 +270,7 @@ empty , silent , and silence are aliases for the empty string ( "" ).
     @Disabled("This also fails to parse in the reference implementation")
     @Test
     public void shouldHandleAintComparisonOfStrings() {
-        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 123 ain’t \"nobody\"", 0);
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 123 ain’t \"all that\"", 0);
         assertTrue((boolean) execute(new Expression(ctx)));
 
         ctx = ParseHelper.getExpression("say \"Tommy\" ain’t \"Tommy\"", 0);
@@ -432,7 +433,6 @@ empty , silent , and silence are aliases for the empty string ( "" ).
 
     /*    "2" ain't Mysterious evaluates to true because all types are non equal to mysterious, besides mysterious itself.
      */
-    @Disabled("Mysterious support")
     @Test
     public void shouldFindAnythingExceptMysteriousIsNotMysterious() {
         Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say \"2\" ain't Mysterious", 0);
@@ -442,12 +442,53 @@ empty , silent , and silence are aliases for the empty string ( "" ).
     /*
    all types are non equal to mysterious, besides mysterious itself
      */
-    @Disabled("Mysterious support")
     @Test
     public void shouldHaveMysteriousEqualToItself() {
         Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say mysterious ain't Mysterious", 0);
         assertFalse((boolean) execute(new Expression(ctx)));
     }
+
+    @Test
+    public void shouldTreatNothingAsEqualToFalse() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say wrong ain't nothing", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say right ain't nothing", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldTreatNothingAsEqualToZero() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 0 ain't nothing", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ParseHelper.getExpression("say nothing ain't 0", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say 0 is nothing", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+    // The spec is a bit vague on this, so this is based on observation in Satriani
+    // (note that on concatenation, null is "null", but I haven't implemented that
+    @Test
+    public void shouldTreatNothingAsEqualToEmptyStringForComparisons() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say \"\" ain't nothing", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say \"\" is nothing", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
+    @Test
+    public void shouldHaveNothingEqualToItself() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say nothing ain't gone", 0);
+        assertFalse((boolean) execute(new Expression(ctx)));
+
+        ctx = ParseHelper.getExpression("say nothing is gone", 0);
+        assertTrue((boolean) execute(new Expression(ctx)));
+    }
+
 
     @Test
     public void shouldCreateResultHandlesOfTheCorrectTypeForStrings() {


### PR DESCRIPTION
The spec says 

> Mysterious - the value of any variable that hasn’t been assigned a value, denoted by the keyword mysterious
> Null - the null type. Evaluates as equal to zero and equal to false. The keywords nothing, nowhere, nobody, and gone are defined as aliases for null

> <Mysterious> <op> Mysterious => Equal.
> <Non-Mysterious> <op> Mysterious => Non equal.

> String <op> Null => Non equal.
> Number <op> Boolean => Convert number to boolean by “truthiness”.
> Number <op> Null => Convert null to 0.
> Boolean <op> Null => Convert null to false.

A naive implementation in byte code would be to treat rockstar `null` as Java `null`, but rockstar null has quite different semantics to Java null. The mysterious value is closer in behaviour to Java `null`. I've created a marker class for `nothing`, and used `null` for `mysterious`. For the `nothing`, I've implemented the type coercion, including to an empty string for String comparison, since Satriani also does that.