### PR TITLE
Format numbers correctly, even when concatenating to strings

### DIFF
--- a/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
@@ -170,6 +170,19 @@ empty , silent , and silence are aliases for the empty string ( "" ).
     }
 
     @Test
+    public void shouldFormatNumbersCorrectlyOnStringAddition() {
+        Rockstar.ExpressionContext ctx = ParseHelper.getExpression("say 99 plus \" red balloons\"", 0);
+        Expression e = new Expression(ctx);
+        String answer = (String) execute(e);
+        assertEquals("99 red balloons", answer);
+
+        ctx = ParseHelper.getExpression("say \"blink\" plus 42", 0);
+        e = new Expression(ctx);
+        answer = (String) execute(e);
+        assertEquals("blink42", answer);
+    }
+
+    @Test
     public void shouldHandleSimpleSubtraction() {
         Rockstar.ExpressionContext ctx = ParseHelper.getExpression("shout 3 - 6", 0);
         Expression a = new Expression(ctx);


### PR DESCRIPTION
We format round numbers without the decimal point when doing a straight `say`, but not if they're concatenated with a string. This PR fixes that; it creates a bit of duplicated Java code and a bit of redundant bytecode, but that can be tidied later. 