### PR TITLE
Support for variable initialisation with operation expressions

### DIFF
--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
@@ -16,10 +16,7 @@ public class Assignment {
     private final Variable variable;
 
     public Assignment(Rockstar.AssignmentStmtContext ctx) {
-        variable = new Variable(ctx.variable());
-        originalName = variable.getVariableName();
-        // Variables should 'apply' to future pronouns when used in assignments
-        variable.track();
+
 
         if (ctx.expression() != null) {
             expression = new Expression(ctx.expression());
@@ -55,6 +52,11 @@ public class Assignment {
                 }
             }
         }
+        variable = new Variable(ctx.variable(), variableClass);
+        originalName = variable.getVariableName();
+        // Variables should 'apply' to future pronouns when used in assignments
+        variable.track();
+
     }
 
     public String getVariableName() {
@@ -71,7 +73,7 @@ public class Assignment {
 
     public void toCode(ClassCreator creator, BytecodeCreator method) {
 
-        FieldDescriptor field = variable.getField(creator, method, getVariableClass());
+        FieldDescriptor field = variable.getField(creator, method);
 
         ResultHandle rh;
 

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Expression.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Expression.java
@@ -73,11 +73,29 @@ public class Expression {
 
                 if (ctx.KW_ADD() != null || "+".equals(ctx.op.getText())) {
                     operation = Operation.ADD;
+                    if (lhe.getValueClass() == double.class && rhe.getValueClass() == double.class) {
+                        valueClass = double.class;
+                    } else if (lhe.getValueClass() == String.class || rhe.getValueClass() == String.class) {
+                        valueClass = String.class;
+                    }
                 } else if (ctx.KW_SUBTRACT() != null || "-".equals(ctx.op.getText())) {
                     operation = Operation.SUBTRACT;
+                    if (lhe.getValueClass() == double.class && rhe.getValueClass() == double.class) {
+                        valueClass = double.class;
+                    }
                 } else if (ctx.KW_MULTIPLY() != null || "*".equals(ctx.op.getText())) {
                     operation = Operation.MULTIPLY;
+
+                    if (lhe.getValueClass() == double.class && rhe.getValueClass() == double.class) {
+                        valueClass = double.class;
+                    } else if (lhe.getValueClass() == String.class || rhe.getValueClass() == String.class) {
+                        valueClass = String.class;
+                    }
+
                 } else if (ctx.KW_DIVIDE() != null || "/".equals(ctx.op.getText())) {
+                    if (lhe.getValueClass() == double.class && rhe.getValueClass() == double.class) {
+                        valueClass = double.class;
+                    }
                     operation = Operation.DIVIDE;
                 }
             }
@@ -93,8 +111,7 @@ public class Expression {
             } else if (variableContext != null) {
                 variable = new Variable(variableContext);
                 value = variable.getVariableName();
-                // A somewhat arbitrary choice, but at least it's a marker
-                valueClass = Variable.class;
+                valueClass = variable.getVariableClass();
 
             }
         }

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/AssignmentTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/AssignmentTest.java
@@ -243,6 +243,19 @@ public class AssignmentTest {
     }
 
     @Test
+    public void shouldHandleInitializeVariableOnAssignment() {
+
+        // No declaration of my hands before put-ing into it
+        String program = """
+                Put 5 of 6 into my hands
+                """;
+        Rockstar.AssignmentStmtContext ctx = ParseHelper.getAssignment(program);
+        Assignment a = new Assignment(ctx);
+        assertEquals(double.class, a.getVariableClass());
+
+    }
+
+    @Test
     public void shouldWriteToClass() {
         Rockstar.AssignmentStmtContext ctx = ParseHelper.getAssignment("My thing is \"hello\"\nEverything is my thing");
         Assignment a = new Assignment(ctx);

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -12,7 +12,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -358,7 +357,7 @@ names in Rockstar.)
         String output = compileAndLaunch(program);
 
         assertEquals("pass\n" +
-                     "pass!\n", output);
+                "pass!\n", output);
 
     }
 
@@ -558,7 +557,6 @@ names in Rockstar.)
         assertEquals("20\n", output);
     }
 
-    @Disabled("Not yet supported")
     @Test
     public void shouldHandleInitializeVariableOnAssignment() {
 


### PR DESCRIPTION
Allows variables to be initialised on assignment, when the other side is an operation. To implement this, I changed to storing type information with the variable object (which is probably a logical place for it). 