### PR TITLE
enable jitpack build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk17
+  - openjdk21

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,3 @@
 jdk:
   - openjdk21
+


### PR DESCRIPTION
add jitpack.yml that will build with java 21.

allows me to run the compiler from anywhere `jbang --repos jitpack,central -m org.example.RockFileCompiler com.github.maxandersen.bon-jova-rockstar-implementation:bon-jova-rockstar-implementation:jitpack-9cace8e1a2-1`

if this gets committed it would be
`jbang --repos jitpack,central -m org.example.RockFileCompiler com.github.holly-cummins.bon-jova-rockstar-implementation:bon-jova-rockstar-implementation:main-SNAPSHOT`

that can be shortened greatly if you add main method in manifest and/or add a jbang-catalog :)
