### PR TITLE
Avoid including compiled rock files in the extension binaries

### DIFF
--- a/bon-jova-app/src/test/java/HelloWorldTest.java
+++ b/bon-jova-app/src/test/java/HelloWorldTest.java
@@ -32,12 +32,13 @@ class HelloWorldTest {
         Method meth = clazz.getMethod("main", String[].class);
         meth.invoke(null, (Object) null);
 
-        assertTrue(testOut.toString()
-                          .contains("Hello World"));
-        assertTrue(testOut.toString()
-                          .contains("Rockstar rockzzzzzzz"));
-        assertTrue(testOut.toString()
-                          .contains("What what?!"));
+        String output = testOut.toString();
+        assertTrue(output
+                .contains("Hello World"), "Output was: " + output);
+        assertTrue(output
+                .contains("Rockstar rockzzzzzzz"), "Output was: " + output);
+        assertTrue(output
+                .contains("What what?!"), "Output was: " + output);
     }
 
     @AfterEach

--- a/bon-jova-quarkus-extension/deployment/src/test/java/org/example/bon/jova/quarkus/extension/deployment/RockstarCompilationProviderTest.java
+++ b/bon-jova-quarkus-extension/deployment/src/test/java/org/example/bon/jova/quarkus/extension/deployment/RockstarCompilationProviderTest.java
@@ -1,7 +1,6 @@
 package org.example.bon.jova.quarkus.extension.deployment;
 
 import io.quarkus.deployment.dev.CompilationProvider;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -18,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RockstarCompilationProviderTest {
     private static final String sourceDirectory = "src/test/resources/";
-    private static final String outputDirectory = "target/classes/";
+    private static final String outputDirectory = "target/test-classes/";
     private static final Set<File> sourceFiles = Set.of(
             new File(sourceDirectory + "hello_world.rock"),
             new File(sourceDirectory + "leet_tommy.rock"));


### PR DESCRIPTION
Resolves #41 

I realised that the thing which is creating the problematic classes is the RockstarCompilationProviderTest, which specifies target/classes as its output directory.

However, switching that to a test output directory exposed a bug in BonJovaQuarkusExtensionTest. It relied on RockstarCompilationProviderTest running first (and leaving output in /test/classes) to pass. I was able to fix that by putting the .rock files into the Shrinkwrap archive, which is good, since that’s a stronger and better test anyway. Sadly, I couldn’t find a way to change the output directory in the Shrinkwrap archive, which meant the compiled rock classes ended up in … `test/classes`. In the end I gave up and put cleanup code in the BonJovaQuarkusExtensionTest.