### PR TITLE
Add menu option 'Rockstar Endpoints' that leads to a full page

### DIFF
--- a/bon-jova-quarkus-extension/deployment/src/main/java/org/example/bon/jova/quarkus/extension/deployment/BonJovaQuarkusExtensionProcessor.java
+++ b/bon-jova-quarkus-extension/deployment/src/main/java/org/example/bon/jova/quarkus/extension/deployment/BonJovaQuarkusExtensionProcessor.java
@@ -3,26 +3,32 @@ package org.example.bon.jova.quarkus.extension.deployment;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.workspace.SourceDir;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalClassLoaderResourcesBuildItem;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.devui.spi.page.Page;
 import org.example.RockFileCompiler;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.example.RockFileCompiler.DOT_CLASS;
 import static org.example.RockFileCompiler.DOT_ROCK;
+
 import org.example.bon.jova.quarkus.extension.runtime.RockstarResource;
 
 class BonJovaQuarkusExtensionProcessor {
@@ -46,17 +52,17 @@ class BonJovaQuarkusExtensionProcessor {
         ApplicationModel model = curateOutcomeBuildItem.getApplicationModel();
 
         if (model.getAppArtifact()
-                 .getWorkspaceModule() != null) {
+                .getWorkspaceModule() != null) {
 
             Collection<SourceDir> sourceDirs = model.getAppArtifact()
-                                                    .getSources()
-                                                    .getSourceDirs();
+                    .getSources()
+                    .getSourceDirs();
 
 
             String[] allCompiledFiles = sourceDirs.stream()
-                                                  .flatMap(this::compileEverythingInDir)
-                                                  .collect(Collectors.toList())
-                                                  .toArray(String[]::new);
+                    .flatMap(this::compileEverythingInDir)
+                    .collect(Collectors.toList())
+                    .toArray(String[]::new);
 
             // Try and add it to the additional classes to index
             // This seems like a reasonable idea, but it fails noisily with null streams, and causes an infinite loop; not doing it has
@@ -72,12 +78,12 @@ class BonJovaQuarkusExtensionProcessor {
         try {
             return Files.list(sourceDir.getDir())
 
-                        .filter(file -> file.toString()
-                                            .endsWith(DOT_ROCK))
-                        .map(java.nio.file.Path::toFile)
-                        .map(file -> compile(sourceDir.getOutputDir(),
-                                file, compiler))
-                        .map(file -> file.getAbsolutePath());
+                    .filter(file -> file.toString()
+                            .endsWith(DOT_ROCK))
+                    .map(java.nio.file.Path::toFile)
+                    .map(file -> compile(sourceDir.getOutputDir(),
+                            file, compiler))
+                    .map(file -> file.getAbsolutePath());
 
             // compiler for the filter, instead
         } catch (IOException e) {
@@ -88,7 +94,7 @@ class BonJovaQuarkusExtensionProcessor {
 
     private File compile(Path buildDir, File file, RockFileCompiler compiler) {
         String outFilename = file.getName()
-                                 .replace(DOT_ROCK, DOT_CLASS);
+                .replace(DOT_ROCK, DOT_CLASS);
         File outFile = new File(buildDir.toFile(), outFilename);
 
         // Check if the file is up to date before compiling, or the compile will trigger a restart, which triggers a compile, which
@@ -113,5 +119,49 @@ class BonJovaQuarkusExtensionProcessor {
     @BuildStep
     void addRockstarResource(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(RockstarResource.class));
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public CardPageBuildItem pages() {
+        var cardPageBuildItem = new CardPageBuildItem();
+        List<RockFileViewModel> rockFiles = generateRockFiles();
+        cardPageBuildItem.addBuildTimeData("rockFiles", rockFiles);
+        cardPageBuildItem.addPage(Page.webComponentPageBuilder()
+                .icon("font-awesome-regular:address-book")
+                .componentLink("qwc-bon-jova-rockstar-endpoints.js")
+                .title("Rockstar Endpoints")
+                .staticLabel(String.valueOf(rockFiles.size())));
+
+        return cardPageBuildItem;
+    }
+
+    private List<RockFileViewModel> generateRockFiles() {
+        try (var stream = Files.list(Path.of("src/main/rockstar"))) {
+            return stream.map(path -> {
+                var fileName = path.getFileName().toString();
+                String contents;
+                try {
+                    contents = Files.readAllLines(path).stream().collect(Collectors.joining(System.lineSeparator()));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+                return new RockFileViewModel(fileName, contents, generateRestUrl(fileName), calculateRockScore(contents));
+            }).toList();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String generateRestUrl(String rockFileName) {
+        return "/rockstar/" + rockFileName;
+    }
+
+    private int calculateRockScore(String contents) {
+        // TODO: calculate a more sophisticated rock store
+        return Math.min(100, contents.length());
+    }
+
+    record RockFileViewModel(String name, String contents, String restUrl, int rockScore) {
     }
 }

--- a/bon-jova-quarkus-extension/deployment/src/main/resources/dev-ui/qwc-bon-jova-rockstar-endpoints.js
+++ b/bon-jova-quarkus-extension/deployment/src/main/resources/dev-ui/qwc-bon-jova-rockstar-endpoints.js
@@ -1,0 +1,30 @@
+import { LitElement, html, css} from 'lit';
+import { rockFiles } from 'build-time-data';
+
+/**
+ * This component shows the Rockstar endpoints.
+ */
+export class QwcBonJovaRockstarEndpoints extends LitElement {
+
+    constructor() {
+        super();
+        this._rockFiles = rockFiles;
+    }
+
+    render() {
+        if (this._rockFiles) {
+            return html`<ul>
+                ${this._rockFiles.map((rockFile) =>
+                html`<li>${rockFile.name}</li>
+                        <ul>
+                            <li>${rockFile.contents}</li>
+                            <li>score: ${rockFile.rockScore}</li>
+                            <li><a href="${rockFile.restUrl}" target="_blank">call endpoint</a></li>
+                        </ul>`
+            )}</ul>`;
+        } else {
+            return html`No Rockstar endpoints found`;
+        }
+    }
+}
+customElements.define('qwc-bon-jova-rockstar-endpoints', QwcBonJovaRockstarEndpoints);

--- a/bon-jova-quarkus-extension/pom.xml
+++ b/bon-jova-quarkus-extension/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <failsafe-plugin.version>${surefire-plugin.version}</failsafe-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.6.4</quarkus.version>

--- a/bon-jova-quarkus-extension/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/bon-jova-quarkus-extension/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 name: "Bon Jova 🎸"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Run Rockstar programs with Quarkus
+description: Shot through the heart and you're to blame! Run your Rockstar programs with Quarkus! 🎵
 metadata:
   keywords:
     - "bon-jova"


### PR DESCRIPTION
Our extension now has a 'Rockstar Endpoints' menu option in the Dev UI! It leads to a static page that has the info on the available endpoints. And: it updates when you add a new .rock file! 🤩 

I haven't spent ANY time on the frontend yet (and it shows!), I'll try to work on that tomorrow. Oh, and we probably need a more sophisticated rock score than just the length of the program. 🤦 

By the way, I changed the extension description to:
> Shot through the heart and you're to blame! Run your Rockstar programs with Quarkus! 🎵

...because it's a LOT more rock 'n roll than what we had before. And as an added bonus I can sing this description live on stage. 😄 

(this PR closes #13 & #14)