### PR TITLE
Improve support for nothing

### DIFF
--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
@@ -89,6 +89,8 @@ public class Assignment {
                 rh = method.load((double) value);
             } else if (boolean.class.equals(variableClass)) {
                 rh = method.load((boolean) value);
+            } else if (Nothing.class.equals(variableClass)) {
+                rh = method.loadNull();
             } else {
                 throw new RuntimeException("Internal error: unknown type " + value);
             }

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
@@ -185,6 +185,10 @@ public class BytecodeGeneratingListener extends RockstarBaseListener {
         CatchBlockCreator catchBlock = tryBlock.addCatch(ClassCastException.class);
         ResultHandle toStringed = Gizmo.toString(catchBlock, value);
         Gizmo.systemOutPrintln(catchBlock, toStringed);
+
+        // When printed on its own, null is ""
+        CatchBlockCreator nullCatchBlock = tryBlock.addCatch(NullPointerException.class);
+        Gizmo.systemOutPrintln(nullCatchBlock, nullCatchBlock.load(""));
     }
 
     @Override

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Constant.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Constant.java
@@ -47,7 +47,15 @@ public class Constant {
         } else if (isBoolean(referenceHandle)) {
             return method.load(false);
         } else if (isString(referenceHandle)) {
-            return method.load("");
+            return method.load("null");
+        } else {
+            return method.loadNull();
+        }
+    }
+
+    public static ResultHandle coerceMysteriousIntoType(BytecodeCreator method, ResultHandle referenceHandle) {
+        if (isString(referenceHandle)) {
+            return method.load("mysterious");
         } else {
             return method.loadNull();
         }

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/AssignmentTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/AssignmentTest.java
@@ -256,19 +256,31 @@ public class AssignmentTest {
     }
 
     @Test
+    public void shouldHandleNull() {
+        Rockstar.AssignmentStmtContext ctx = ParseHelper.getAssignment("My thing is nothing");
+        Assignment a = new Assignment(ctx);
+
+        toCode(a);
+        // It's hard to make many sensible assertions without making a mock and asserting about to the calls, and that's
+        // awfully close to just writing the code down twice, so just be happy if we get here without explosions
+    }
+
+    @Test
     public void shouldWriteToClass() {
         Rockstar.AssignmentStmtContext ctx = ParseHelper.getAssignment("My thing is \"hello\"\nEverything is my thing");
         Assignment a = new Assignment(ctx);
+        toCode(a);
+        // It's hard to make many sensible assertions without making a mock and asserting about to the calls, and that's
+        // awfully close to just writing the code down twice, so just be happy if we get here without explosions
+    }
 
+    private static void toCode(Assignment a) {
         ClassCreator creator = ClassCreator.builder()
                 .className("holder")
                 .build();
         MethodCreator method = creator.getMethodCreator("main", void.class, String[].class);
 
         a.toCode(creator, method);
-        // It's hard to make many sensible assertions without making a mock and asserting about to the calls, and that's
-        // awfully close to just writing the code down twice, so just be happy if we get here without explosions
-
     }
 
 }

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -139,7 +139,27 @@ names in Rockstar.)
         String output = compileAndLaunch(program);
 
         assertEquals("764\n", output);
+    }
 
+    @Test
+    public void shouldHandleNothingInAVariable() {
+        String program = """
+                My world is nothing 
+                Shout my world
+                                            """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("\n", output);
+    }
+
+    @Test
+    public void shouldHandleNothingInALiteral() {
+        String program = """
+                Shout nothing
+                                            """;
+        String output = compileAndLaunch(program);
+
+        assertEquals("\n", output);
     }
 
     @Test


### PR DESCRIPTION
Some uses of `nothing` were causing failures, such as fizz buzz and even `my world is nothing`. This PR adds more tests and fixes the exposed issues.  