### PR TITLE
Trial run: give more informative error message when state leaks

### DIFF
--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
@@ -116,7 +116,6 @@ public class Variable {
     public FieldDescriptor getField(ClassCreator creator, BytecodeCreator method) {
         FieldDescriptor field;
         if (!variables.containsKey(variableName)) {
-
             // Variables are global in scope, so need to be stored at the class level (either as static or instance variables)
             field = creator.getFieldCreator(variableName, variableClass)
                     .setModifiers(Opcodes.ACC_STATIC + Opcodes.ACC_PRIVATE)
@@ -124,6 +123,9 @@ public class Variable {
             variables.put(variableName, field);
         } else {
             field = variables.get(variableName);
+            if (!creator.getClassName().equals(field.getDeclaringClass())) {
+                throw new RuntimeException("Internal error: Attempting to use a field on class " + field.getDeclaringClass() + " from " + creator.getClassName());
+            }
         }
         return field;
     }


### PR DESCRIPTION
Obviously, #50  should Never Happen, and hopefully the code is now fixed so it doesn't. However, it would be useful to get better diagnostics when it does, so I've put in a little failsafe check. It won't catch the case where state leaks between classes of the same name, but I think such errors wouldn't actually affect the bytecode.

Initial PR designed to exercise failure path gives

```
Error:  shouldSetValueBasedOnStdIn  Time elapsed: 0.006 s  <<< ERROR!
java.lang.RuntimeException: Internal error: Attempting to use a field on class rock14973921548021469241 from com/InputRock
	at org.example.InputTest.execute(InputTest.java:76)
	at org.example.InputTest.shouldSetValueBasedOnStdIn(InputTest.java:44)
```