### PR TITLE
Basic array support

### DIFF
--- a/bon-jova-app/src/main/rockstar/the_answer_to_life_the_universe_and_everything.rock
+++ b/bon-jova-app/src/main/rockstar/the_answer_to_life_the_universe_and_everything.rock
@@ -1,3 +1,3 @@
 (This program prints the ultimate answer)
-Answer is rock it
-Shout Answer
+The answer is sing it
+Shout the answer

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
@@ -6,7 +6,7 @@ program: (NL|ws)* (statementList | functionDeclaration)* ws*;
 
 statementList: statement+;
 
-statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | returnStmt | continueStmt | breakStmt) (NL+?|EOF);
+statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | arrayStmt | returnStmt | continueStmt | breakStmt) (NL+?|EOF);
 
 expression: functionCall
           | lhe=expression ws op=(KW_MULTIPLY|KW_DIVIDE) ws rhe=expression
@@ -17,10 +17,17 @@ expression: functionCall
           | lhe=expression contractedComparisionOp ws rhe=expression
           | lhe=expression ws op=(KW_AND|KW_OR|KW_NOR) ws rhe=expression
           | KW_NOT ws rhe=expression
+          | variable ws KW_AT ws expression
           | (literal|variable|constant)
 ;
 
+list: (expression) (COMMA ws expression)*;
+
 functionCall: functionName=variable WS KW_TAKING WS argList;
+
+arrayStmt: KW_ROCK ws variable
+       | KW_ROCK ws list ws KW_INTO ws variable
+;
 
 // the second set of entries here isn't just an expression, to try and force the shortest match, rather than the longest match
 argList: (expression) ((WS KW_AND|COMMA|WS AMPERSAND|WS APOSTROPHED_N) WS (literal|variable|constant|expression))*;

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
@@ -131,6 +131,11 @@ KW_NOR: N O R;
 KW_TURN: T U R N;
 KW_ROUND: R O U N D | A R O U N D;
 
+KW_ROCK: R O C K | P U S H;
+KW_ROLL: R O L L | P O P;
+KW_AT: A T;
+
+
 PROPER_NOUN: [A-Z][A-Z|a-z]*;
 WORD: [a-z|A-Z]+;
 

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Array.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Array.java
@@ -1,0 +1,97 @@
+package org.example;
+
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import rock.Rockstar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.example.Constant.coerceNothingIntoType;
+import static org.example.Expression.coerceAwayNothing;
+
+public class Array {
+    private static final MethodDescriptor LIST_CONSTRUCTOR = MethodDescriptor.ofConstructor(ArrayList.class);
+    private static final MethodDescriptor ADD_METHOD = MethodDescriptor.ofMethod(ArrayList.class, "add", boolean.class, Object.class);
+    private static final MethodDescriptor GET_METHOD = MethodDescriptor.ofMethod(ArrayList.class, "get", Object.class, int.class);
+    private static final MethodDescriptor LENGTH_METHOD = MethodDescriptor.ofMethod(ArrayList.class, "size", int.class);
+    private static final MethodDescriptor DOUBLE_METHOD = MethodDescriptor.ofMethod(Integer.class, "doubleValue", double.class);
+    private static final MethodDescriptor INT_METHOD = MethodDescriptor.ofMethod(Double.class, "intValue", int.class);
+
+    private final Class<?> variableClass;
+    private final Variable variable;
+    public static final Class<?> TYPE_CLASS = List.class;
+    private List<Expression> initialContents;
+
+    public Array(Rockstar.ArrayStmtContext ctx) {
+        // TODO two variables, or an intermediate class to handle the map/list duality?
+        // Or just always use a map, and track our index?
+        variableClass = TYPE_CLASS;
+        variable = new Variable(ctx.variable(), variableClass);
+        // Variables should 'apply' to future pronouns when used in assignments
+        variable.track();
+
+        if (ctx.list() != null) {
+            initialContents = ctx.list().expression().stream().map(Expression::new).toList();
+        }
+    }
+
+    public Array(Variable variable) {
+        this.variable = variable;
+        variableClass = variable.getVariableClass();
+    }
+
+    public String getVariableName() {
+        return variable.getVariableName();
+    }
+
+    public static ResultHandle toScalarContext(Variable variable, BytecodeCreator method) {
+        ResultHandle arr = variable.read(method);
+        ResultHandle intLength = method.invokeVirtualMethod(LENGTH_METHOD, arr);
+        // We work in doubles everywhere, so convert to a double; use doubleValue not a cast, since the dynamic invocation actually gave us an Integer
+        return method.invokeVirtualMethod(DOUBLE_METHOD, intLength);
+    }
+
+    public ResultHandle read(Expression arrayAccessIndex, BytecodeCreator method, ClassCreator creator) {
+        ResultHandle rh = variable.read(method);
+        ResultHandle index;
+        if (arrayAccessIndex.isNothing()) {
+            index = coerceNothingIntoType(method, method.load(0d));
+        } else {
+            index = arrayAccessIndex.getResultHandle(method, creator);
+            // This could still be a null, so do another check
+            index = coerceAwayNothing(method, index, method.load(0d));
+
+        }
+        index = method.invokeVirtualMethod(INT_METHOD, index);
+        return method.invokeVirtualMethod(GET_METHOD, rh, index);
+    }
+
+    public ResultHandle toCode(BytecodeCreator method, ClassCreator creator) {
+
+        // TODO it would be nice to specify the initial capacity, even if creating a collection to initialise it with is too tricky
+        ResultHandle rh;
+
+        if (variable.isAlreadyDefined()) {
+            rh = variable.read(method);
+        } else {
+            rh = method.newInstance(LIST_CONSTRUCTOR);
+            // TODO refactor so getting the field is private
+            FieldDescriptor field = variable.getField(creator, method);
+            method.writeStaticField(field, rh);
+        }
+
+        if (initialContents != null) {
+            for (Expression c : initialContents) {
+                method.invokeVirtualMethod(ADD_METHOD, rh, c.getResultHandle(method, creator));
+            }
+        }
+
+        // Return the result handle for ease of testing
+        return rh;
+
+    }
+}

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
@@ -14,9 +14,12 @@ public class Assignment {
     private final Object value;
     private final Class<?> variableClass;
     private final Variable variable;
+    private final String text;
     private Expression expression;
 
     public Assignment(Rockstar.AssignmentStmtContext ctx) {
+        this.text = ctx.getText();
+
         if (ctx.expression() != null) {
             expression = new Expression(ctx.expression());
             value = expression.getValue();
@@ -92,7 +95,7 @@ public class Assignment {
             } else if (value == NOTHING) { // We can't check the type, because Nothings are stored as objects in case they get coerced
                 rh = method.loadNull();
             } else {
-                throw new RuntimeException("Internal error: unknown type " + value);
+                throw new RuntimeException("Internal error: unknown type " + value + " in assigment '" + text + "'");
             }
         }
 

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
@@ -98,13 +98,16 @@ public class Variable {
     }
 
     public ResultHandle read(BytecodeCreator method) {
-        if (variables.containsKey(variableName)) {
+        if (isAlreadyDefined()) {
             return method.readStaticField(variables.get(variableName));
-
         } else {
             // This is an internal error, not a program one
             throw new RuntimeException("Moral panic: Could not find variable called " + variableName);
         }
+    }
+
+    public boolean isAlreadyDefined() {
+        return variables.containsKey(variableName);
     }
 
     public void write(BytecodeCreator method, ResultHandle value) {
@@ -115,7 +118,7 @@ public class Variable {
     // TODO would it be nicer to store our own class?
     public FieldDescriptor getField(ClassCreator creator, BytecodeCreator method) {
         FieldDescriptor field;
-        if (!variables.containsKey(variableName)) {
+        if (!isAlreadyDefined()) {
             // Variables are global in scope, so need to be stored at the class level (either as static or instance variables)
             field = creator.getFieldCreator(variableName, variableClass)
                     .setModifiers(Opcodes.ACC_STATIC + Opcodes.ACC_PRIVATE)

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/ArrayTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/ArrayTest.java
@@ -1,0 +1,125 @@
+package org.example;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TestClassLoader;
+import org.example.util.ParseHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import rock.Rockstar;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ArrayTest {
+
+    @BeforeEach
+    public void clearState() {
+        Variable.clearState();
+    }
+
+    @Test
+    public void shouldParseVariableNameWithSimpleVariableArray() {
+        Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray("Rock thing");
+        Array a = new Array(ctx);
+        // Variable names should be normalised to lower case
+        String name = "thing";
+        assertEquals(name, a.getVariableName());
+    }
+
+    @Test
+    public void shouldParseVariableNameWithCommonVariableArray() {
+        Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray("Rock my thing");
+        Array a = new Array(ctx);
+        // Variable names should be normalised to lower case
+        String name = "my__thing";
+        assertEquals(name, a.getVariableName());
+    }
+
+    @Test
+    public void shouldParseVariableNameWithProperVariableArray() {
+        Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray("Rock Doctor Feelgood");
+        Array a = new Array(ctx);
+        // Variable names should be normalised to lower case
+        assertEquals("doctor__feelgood", a.getVariableName());
+    }
+
+    @Test
+    public void shouldCreateAnArrayOnInitialisationWithRock() {
+        Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray("Rock the thing");
+        assertEquals(new ArrayList<Object>(), execute(new Array(ctx)));
+    }
+
+    @Test
+    public void shouldCreateAnArrayOnInitialisationWithPush() {
+        Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray("Push the thing");
+        assertEquals(new ArrayList<Object>(), execute(new Array(ctx)));
+    }
+
+    @Test
+    public void shouldPopulateArrayOnInitialisationWithSingleElement() {
+        String program = """
+                Rock 4 into arr
+                """;
+        Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
+        Object[] contents = {4d};
+        assertEquals(Arrays.asList(contents), execute(new Array(ctx)));
+
+    }
+
+    @Test
+    public void shouldPopulateArrayOnInitialisationWithList() {
+        String program = """
+                Rock 1, 2, 3, 4, 8 into arr
+                """;
+        Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
+        Object[] contents = {1d, 2d, 3d, 4d, 8d};
+        assertEquals(Arrays.asList(contents), execute(new Array(ctx)));
+
+    }
+
+    @Test
+    public void shouldPopulateArrayOnInitialisationWithSingleExpression() {
+        String program = """
+                Rock 4 + 5 into me
+                """;
+        Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
+        Object[] contents = {9d};
+        assertEquals(Arrays.asList(contents), execute(new Array(ctx)));
+
+    }
+
+    private Object execute(Array a) {
+        TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader().getParent());
+
+        // The auto-close on this triggers the write
+        String className = "com.ArrayTest";
+        String methodName = "method";
+        try (ClassCreator creator = ClassCreator.builder()
+                .classOutput(cl)
+                .className(className)
+                .build()) {
+
+            MethodCreator method = creator.getMethodCreator(methodName, Object.class)
+                    .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle rh = a.toCode(method, creator);
+            method.returnValue(rh);
+        }
+
+        try {
+            Class<?> clazz = cl.loadClass(className);
+            return clazz.getMethod(methodName)
+                    .invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException |
+                 InvocationTargetException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Test error: " + e);
+        }
+    }
+
+}

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -1342,6 +1342,133 @@ names in Rockstar.)
         }
     }
 
+    @Nested
+    class Arrays {
+        @Test
+        public void shouldInitialiseAnArrayWithRock() {
+            String program = """
+                    Rock the array
+                    Say the array
+                    """;
+            String output = compileAndLaunch(program);
+
+            assertEquals("0\n", output);
+        }
+
+        @Test
+        public void shouldOutputArrayLength() {
+            String program = """
+                    Rock 1, 2, 3, 4, 8 into arr
+                    Say arr
+                    """;
+            String output = compileAndLaunch(program);
+
+            assertEquals("5\n", output);
+        }
+
+        // Returning an array in a scalar context will return the current length of the array
+        @Test
+        public void shouldUseLengthOfArrayInAScalarContext() {
+            String program = """
+                    rock 5, 4, 2 into me
+                    say me
+                    say me times 2
+                    say me plus 8
+                                        """;
+            String output = compileAndLaunch(program);
+
+            assertEquals("3\n6\n11\n", output);
+        }
+
+        @Test
+        public void shouldUseLengthOfArrayWhenConcatenatingToStrings() {
+            String program = """
+                    rock 1, 3 into arr
+                    say arr + "length"
+                                        """;
+            String output = compileAndLaunch(program);
+
+            assertEquals("2length\n", output);
+        }
+
+        @Test
+        public void shouldUseLengthOfArrayInAScalarContextEvenIfArrayIsWrappedInAVariable() {
+            String program = """
+                    rock 5, 4, 2 into me
+                    let you be me
+                    say you times 2
+                    say you plus 8
+                                        """;
+            String output = compileAndLaunch(program);
+
+            assertEquals("6\n11\n", output);
+        }
+
+        @Test
+        public void shouldIncreaseLengthWhenAppendingToArray() {
+            String program = """
+                    rock arr
+                    rock 1 into arr
+                    rock 5 into arr
+                    rock 8 into arr
+                    say arr
+                                                            """;
+            String output = compileAndLaunch(program);
+
+            assertEquals("3\n", output);
+        }
+
+        @Test
+        public void shouldPutContentInRightPlaceWhenAppendingToArray() {
+            String program = """
+                    rock arr
+                    rock 1 into arr
+                    rock 5 into arr
+                    rock 8 into arr
+                    say arr at 1
+                    say arr at 2
+                    say arr at 0
+                                                            """;
+            String output = compileAndLaunch(program);
+
+            assertEquals("5\n8\n1\n", output);
+        }
+
+        @Test
+        public void shouldBeAbleToAccessArrayUsingExpressions() {
+            String program = """
+                    rock arr
+                    rock 1 into arr
+                    rock 5 into arr
+                    rock 8 into arr
+                    fred is 1
+                    jane is 0
+                    say arr at 1 + 1
+                    say arr at jane
+                    say arr at fred
+                                                            """;
+            String output = compileAndLaunch(program);
+
+            assertEquals("8\n1\n5\n", output);
+        }
+
+        @Test
+        public void shouldBeAbleToAccessArrayUsingNothingExpressions() {
+            String program = """
+                    rock arr
+                    rock 1 into arr
+                    rock 5 into arr
+                    rock 8 into arr
+                    say arr at nothing
+                    jane is nothing
+                    say arr at jane
+                                                            """;
+            String output = compileAndLaunch(program);
+
+            assertEquals("1\n1\n", output);
+        }
+    }
+
     private String compileAndLaunch(String program, String... args) {
         // Save the current System.out for later restoration
         PrintStream originalOut = System.out;

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/ExpressionTest.java
@@ -731,32 +731,6 @@ empty , silent , and silence are aliases for the empty string ( "" ).
         }
     }
 
-    private Object execute(Expression a) {
-        TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader().getParent());
-
-        // The auto-close on this triggers the write
-        try (ClassCreator creator = ClassCreator.builder()
-                .classOutput(cl)
-                .className("com.MyTest")
-                .build()) {
-
-            MethodCreator method = creator.getMethodCreator("method", Object.class)
-                    .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
-            ResultHandle rh = a.getResultHandle(method, creator);
-            method.returnValue(rh);
-        }
-
-        try {
-            Class<?> clazz = cl.loadClass("com.MyTest");
-            return clazz.getMethod("method")
-                    .invoke(null);
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException |
-                 InvocationTargetException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Test error: " + e);
-        }
-    }
-
     // This is a whole section of implementation, but handle some simple cases
     @Nested
     @DisplayName("Types of operations on types")
@@ -801,6 +775,32 @@ empty , silent , and silence are aliases for the empty string ( "" ).
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
             assertEquals(String.class, a.getValueClass());
+        }
+    }
+
+    private Object execute(Expression a) {
+        TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader().getParent());
+
+        // The auto-close on this triggers the write
+        try (ClassCreator creator = ClassCreator.builder()
+                .classOutput(cl)
+                .className("com.MyTest")
+                .build()) {
+
+            MethodCreator method = creator.getMethodCreator("method", Object.class)
+                    .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle rh = a.getResultHandle(method, creator);
+            method.returnValue(rh);
+        }
+
+        try {
+            Class<?> clazz = cl.loadClass("com.MyTest");
+            return clazz.getMethod("method")
+                    .invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException |
+                 InvocationTargetException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Test error: " + e);
         }
     }
 }

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/util/CapturingListener.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/util/CapturingListener.java
@@ -19,8 +19,8 @@ public class CapturingListener extends RockstarBaseListener {
     private Rockstar.VariableContext variable;
     private Rockstar.IfStmtContext ifCondition;
     private Rockstar.InputStmtContext input;
-
     private Rockstar.RoundingStmtContext rounding;
+    private Rockstar.ArrayStmtContext array;
 
     @Override
     public void enterAssignmentStmt(Rockstar.AssignmentStmtContext assignmentStatement) {
@@ -71,6 +71,11 @@ public class CapturingListener extends RockstarBaseListener {
         this.rounding = ctx;
     }
 
+    @Override
+    public void enterArrayStmt(Rockstar.ArrayStmtContext ctx) {
+        this.array = ctx;
+    }
+
     public Rockstar.PoeticNumberLiteralContext getPoeticNumberLiteral() {
         return poeticNumberLiteral;
     }
@@ -105,5 +110,9 @@ public class CapturingListener extends RockstarBaseListener {
 
     public Rockstar.RoundingStmtContext getRounding() {
         return rounding;
+    }
+
+    public RuleContext getArray() {
+        return array;
     }
 }

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
@@ -60,6 +60,10 @@ public class ParseHelper {
         return new RoundingAndAssignmentPair(listener.getAssignmentStatement(), listener.getRounding());
     }
 
+    public Rockstar.ArrayStmtContext getArray(String program) {
+        return (Rockstar.ArrayStmtContext) getGrammarElement(program, CapturingListener::getArray);
+    }
+
     private RuleContext getGrammarElement(String program, Function<CapturingListener,
             RuleContext> getter) {
 /*


### PR DESCRIPTION
This PR implements very basic array support; there is no `roll` support or support for non-numeric keys, or support for advanced features like poetic literals. However, programs like the following now work:

```
                    rock arr
                    rock 1 into arr
                    rock 5 into arr
                    rock 8 into arr
                    fred is 1
                    jane is nothing
                    say arr at 1 + 1
                    say arr at jane
                    say arr at fred
```