### PR TITLE
Add support for splitting strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ Some of these may work but have not been validated with tests.
 
 ## Splitting and joining strings
 
-- [ ] Split a string in Rockstar, use the `cut` mutation (aliases `split` and `shatter`)
-- [ ] Delimiters
+- [X] Split a string in Rockstar, use the `cut` mutation (aliases `split` and `shatter`)
+- [ ] Split strings in place
+- [X] Delimiters
 - [ ] The `join` support
 
 ## Casting

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
@@ -6,7 +6,7 @@ program: (NL|ws)* (statementList | functionDeclaration)* ws*;
 
 statementList: statement+;
 
-statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | arrayStmt | returnStmt | continueStmt | breakStmt) (NL+?|EOF);
+statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | arrayStmt | stringStmt | returnStmt | continueStmt | breakStmt) (NL+?|EOF);
 
 expression: functionCall
           | lhe=expression ws op=(KW_MULTIPLY|KW_DIVIDE) ws rhe=expression
@@ -27,6 +27,11 @@ list: (expression) (COMMA ws expression)*;
 arrayStmt: KW_ROCK ws variable
        | KW_ROCK ws list ws KW_INTO ws variable
        | KW_ROCK ws variable ws KW_WITH ws list
+;
+
+stringStmt: KW_SPLIT ws expression?? ws KW_WITH ws expression
+        | KW_SPLIT ws expression?? (ws KW_INTO ws variable)? (ws KW_WITH ws expression)?
+        | KW_SPLIT ws expression?? (ws KW_WITH ws expression)? (ws KW_INTO ws variable)?
 ;
 
 functionCall: functionName=variable WS KW_TAKING WS argList;

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
@@ -136,6 +136,7 @@ KW_ROCK: R O C K | P U S H;
 KW_ROLL: R O L L | P O P;
 KW_AT: A T;
 
+KW_SPLIT: C U T | S P L I T | S H A T T E R;
 
 PROPER_NOUN: [A-Z][A-Z|a-z]*;
 WORD: [a-z|A-Z]+;

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Array.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Array.java
@@ -17,10 +17,10 @@ import static org.example.Expression.coerceAwayNothing;
 
 public class Array {
     private static final MethodDescriptor LIST_CONSTRUCTOR = MethodDescriptor.ofConstructor(ArrayList.class);
-    private static final MethodDescriptor ADD_METHOD = MethodDescriptor.ofMethod(ArrayList.class, "add", boolean.class, Object.class);
-    private static final MethodDescriptor GET_METHOD = MethodDescriptor.ofMethod(ArrayList.class, "get", Object.class, int.class);
-    private static final MethodDescriptor REMOVE_METHOD = MethodDescriptor.ofMethod(ArrayList.class, "remove", Object.class, int.class);
-    private static final MethodDescriptor LENGTH_METHOD = MethodDescriptor.ofMethod(ArrayList.class, "size", int.class);
+    static final MethodDescriptor ADD_METHOD = MethodDescriptor.ofMethod(List.class, "add", boolean.class, Object.class);
+    private static final MethodDescriptor GET_METHOD = MethodDescriptor.ofMethod(List.class, "get", Object.class, int.class);
+    private static final MethodDescriptor REMOVE_METHOD = MethodDescriptor.ofMethod(List.class, "remove", Object.class, int.class);
+    private static final MethodDescriptor LENGTH_METHOD = MethodDescriptor.ofMethod(List.class, "size", int.class);
     private static final MethodDescriptor DOUBLE_METHOD = MethodDescriptor.ofMethod(Integer.class, "doubleValue", double.class);
     private static final MethodDescriptor INT_METHOD = MethodDescriptor.ofMethod(Double.class, "intValue", int.class);
 
@@ -53,7 +53,7 @@ public class Array {
 
     public static ResultHandle toScalarContext(Variable variable, BytecodeCreator method) {
         ResultHandle arr = variable.read(method);
-        ResultHandle intLength = method.invokeVirtualMethod(LENGTH_METHOD, arr);
+        ResultHandle intLength = method.invokeInterfaceMethod(LENGTH_METHOD, arr);
         // We work in doubles everywhere, so convert to a double; use doubleValue not a cast, since the dynamic invocation actually gave us an Integer
         return method.invokeVirtualMethod(DOUBLE_METHOD, intLength);
     }
@@ -70,7 +70,7 @@ public class Array {
 
         }
         index = method.invokeVirtualMethod(INT_METHOD, index);
-        return method.invokeVirtualMethod(GET_METHOD, rh, index);
+        return method.invokeInterfaceMethod(GET_METHOD, rh, index);
     }
 
     public ResultHandle toCode(BytecodeCreator method, ClassCreator creator) {
@@ -89,7 +89,7 @@ public class Array {
 
         if (initialContents != null) {
             for (Expression c : initialContents) {
-                method.invokeVirtualMethod(ADD_METHOD, rh, c.getResultHandle(method, creator));
+                method.invokeInterfaceMethod(ADD_METHOD, rh, c.getResultHandle(method, creator));
             }
         }
 
@@ -102,11 +102,11 @@ public class Array {
         ResultHandle arr = variable.read(method);
         ResultHandle index = method.load(0);
         AssignableResultHandle answer = method.createVariable(Object.class);
-        ResultHandle intLength = method.invokeVirtualMethod(LENGTH_METHOD, arr);
+        ResultHandle intLength = method.invokeInterfaceMethod(LENGTH_METHOD, arr);
         BranchResult br = method.ifGreaterThanZero(intLength);
         // Deleting the element returns it, so it acts as a pop
         BytecodeCreator trueBranch = br.trueBranch();
-        trueBranch.assign(answer, trueBranch.invokeVirtualMethod(REMOVE_METHOD, arr, index));
+        trueBranch.assign(answer, trueBranch.invokeInterfaceMethod(REMOVE_METHOD, arr, index));
         BytecodeCreator falseBranch = br.falseBranch();
         falseBranch.assign(answer, falseBranch.loadNull()); // This should be mysterious
         return answer;

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/BytecodeGeneratingListener.java
@@ -361,6 +361,12 @@ public class BytecodeGeneratingListener extends RockstarBaseListener {
     }
 
     @Override
+    public void enterStringStmt(Rockstar.StringStmtContext ctx) {
+        new StringSplit(ctx).toCode(currentCreator, creator);
+    }
+
+
+    @Override
     public void enterFunctionDeclaration(Rockstar.FunctionDeclarationContext ctx) {
         // A function creator in Gizmo is like a lambda, which is not really what we want, so use methods
         // TODO the scope of these should be local, not global

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/StringSplit.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/StringSplit.java
@@ -1,0 +1,97 @@
+package org.example;
+
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.WhileLoop;
+import rock.Rockstar;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.example.Array.ADD_METHOD;
+import static org.example.Array.TYPE_CLASS;
+
+public class StringSplit {
+    private static final MethodDescriptor SPLIT_METHOD = MethodDescriptor.ofMethod(String.class, "split", String[].class, String.class);
+    private static final MethodDescriptor LENGTH_METHOD = MethodDescriptor.ofMethod(String.class, "length", int.class);
+
+    private static final MethodDescriptor ASLIST_METHOD = MethodDescriptor.ofMethod(Arrays.class, "asList", List.class, Object[].class);
+    private static final MethodDescriptor CHAR_AT_METHOD = MethodDescriptor.ofMethod(String.class, "charAt", char.class, int.class);
+
+    private final Class<?> variableClass;
+    private final Variable variable;
+    private Expression source;
+    private Expression delimiter;
+
+    public StringSplit(Rockstar.StringStmtContext ctx) {
+        variableClass = TYPE_CLASS;
+        // We definitely have one expression ...
+        Rockstar.ExpressionContext sourceCtx = ctx.expression().get(0);
+        source = new Expression(sourceCtx);
+
+        if (ctx.variable() == null) {
+            // If we're splitting in place, the expression had better just be a variable
+            if (sourceCtx.variable() == null) {
+                throw new RuntimeException("Cannot cut without a variable.");
+            }
+            variable = new Variable(sourceCtx.variable(), variableClass);
+        } else {
+            variable = new Variable(ctx.variable(), variableClass);
+            // Variables should 'apply' to future pronouns when used in assignments
+            variable.track();
+        }
+
+        if (ctx.KW_WITH() != null) {
+            delimiter = new Expression(ctx.expression().get(1));
+        }
+    }
+
+    public String getVariableName() {
+        return variable.getVariableName();
+    }
+
+    public ResultHandle toCode(BytecodeCreator method, ClassCreator creator) {
+
+
+        ResultHandle toSplit = source.getResultHandle(method, creator);
+        ResultHandle answer;
+        if (delimiter != null) {
+            ResultHandle delimiterHandle = delimiter.getResultHandle(method, creator);
+            ResultHandle splitArray = method.invokeVirtualMethod(SPLIT_METHOD, toSplit, delimiterHandle);
+            answer = method.invokeStaticMethod(ASLIST_METHOD, splitArray);
+        } else {
+            // Doing the lambda in bytecode is hard, so just do a while loop
+            // and working with the int stream is also hard ...
+            // ... and working with the primitive array is also hard ...
+            ResultHandle length = method.invokeVirtualMethod(LENGTH_METHOD, toSplit);
+
+            answer = Gizmo.newArrayList(method);
+
+            AssignableResultHandle index = method.createVariable(int.class);
+            method.assign(index, method.load(0));
+            WhileLoop loop = method.whileLoop(bc -> bc.ifIntegerLessThan(index, length));
+            BytecodeCreator block = loop.block();
+            ResultHandle charAsString = block.invokeVirtualMethod(CHAR_AT_METHOD, toSplit, index);
+
+            block.invokeInterfaceMethod(ADD_METHOD, answer, charAsString);
+            block.assign(index, block.increment(index));
+        }
+
+        if (!variable.isAlreadyDefined()) {
+            // TODO refactor so getting the field is private
+            variable.getField(creator, method);
+        }
+
+        variable.write(method, answer);
+
+        // Return the result handle for ease of testing
+        return answer;
+
+    }
+}
+
+

--- a/bon-jova-rockstar-implementation/src/test/java/StringSplitTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/StringSplitTest.java
@@ -1,0 +1,96 @@
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TestClassLoader;
+import org.example.StringSplit;
+import org.example.Variable;
+import org.example.util.ParseHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import rock.Rockstar;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class StringSplitTest {
+
+    @BeforeEach
+    public void clearState() {
+        Variable.clearState();
+    }
+
+    @Test
+    public void shouldParseVariableNameWithSimpleVariableStringSplit() {
+        Rockstar.StringStmtContext ctx = new ParseHelper().getStringSplit("Cut \"my life\" into pieces");
+        StringSplit a = new StringSplit(ctx);
+        // Variable names should be normalised to lower case
+        String name = "pieces";
+        assertEquals(name, a.getVariableName());
+    }
+
+    @Test
+    public void shouldFailToSplitWithoutAVariable() {
+        assertThrows(RuntimeException.class, () -> new StringSplit(new ParseHelper().getStringSplit("Cut \"my life\"")));
+    }
+
+    @Test
+    public void shouldCreateAnArrayOnSimpleSplit() {
+        Rockstar.StringStmtContext ctx = new ParseHelper().getStringSplit("Cut \"\" into pieces");
+        assertDeepEquals(new ArrayList<String>(), execute(new StringSplit(ctx)));
+    }
+
+    @Test
+    public void shouldSplitIntoCharacterArrayWithNoDelimiter() {
+        List expected = Arrays.asList("h", "e", "l", "l", "o");
+        Rockstar.StringStmtContext ctx = new ParseHelper().getStringSplit("Cut \"hello\" into pieces");
+        assertDeepEquals(expected, execute(new StringSplit(ctx)));
+    }
+
+    @Test
+    public void shouldSplitIntoCharacterArrayHonouringDelimiter() {
+        List expected = Arrays.asList("first", "second");
+        Rockstar.StringStmtContext ctx = new ParseHelper().getStringSplit("Cut \"first, second\" into pieces with \", \"");
+        assertDeepEquals(expected, execute(new StringSplit(ctx)));
+    }
+
+    private static void assertDeepEquals(List a, List b) {
+        // The class may be different, so dump to string
+        assertEquals(Arrays.toString(a.toArray()), Arrays.toString(b.toArray()));
+    }
+
+    private List execute(StringSplit a) {
+        TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader().getParent());
+
+        // The auto-close on this triggers the write
+        String className = "com.StringSplitTest";
+        String methodName = "method";
+        try (ClassCreator creator = ClassCreator.builder()
+                .classOutput(cl)
+                .className(className)
+                .build()) {
+
+            MethodCreator method = creator.getMethodCreator(methodName, Object.class)
+                    .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle rh = a.toCode(method, creator);
+            method.returnValue(rh);
+        }
+
+        try {
+            Class<?> clazz = cl.loadClass(className);
+            return (List) clazz.getMethod(methodName)
+                    .invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException |
+                 InvocationTargetException e) {
+            fail(e);
+            return null;
+        }
+    }
+
+}

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -1344,6 +1344,57 @@ names in Rockstar.)
     }
 
     @Nested
+    class Strings {
+
+        @Disabled("Needs support for changing the type of a variable")
+        @Test
+        public void shouldSplitStringsInPlace() {
+            String program = """
+                    My life is "misery"
+                    Cut my life
+                    Say my life
+                    """;
+            assertEquals("6\n", compileAndLaunch(program));
+        }
+
+        @Test
+        public void shouldSplitStringsIntoCharArrays() {
+            String program = """
+                    My life is "one two"
+                    Cut my life into pieces
+                    Say pieces
+                    """;
+            assertEquals("7\n", compileAndLaunch(program));
+        }
+
+        @Disabled("Needs support for changing the type of a variable")
+        @Test
+        public void shouldSplitStringsInPlaceWithDelimiter() {
+            String program = """
+                    Your cake is "chocolate"
+                    My knife is "o"
+                    Cut your cake with my knife
+                    """;
+
+            assertEquals("3\n", compileAndLaunch(program));
+
+        }
+
+        @Test
+        public void shouldSplitStringsUsingADelimiter() {
+            String program = """
+                    Your deceit is " "
+                    My heart is "a string with spaces"
+                    Shatter my heart into pieces with your deceit
+                    Say pieces
+                    """;
+
+            assertEquals("4\n", compileAndLaunch(program));
+
+        }
+    }
+
+    @Nested
     class Arrays {
         @Test
         public void shouldInitialiseAnArrayWithRock() {

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/VariableTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/VariableTest.java
@@ -6,6 +6,7 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
 import org.example.util.ParseHelper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import rock.Rockstar;
 
@@ -70,6 +71,18 @@ public class VariableTest {
         String program = """
                 My             thing is true
                 Shout my   thing
+                                            """;
+        Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
+        Variable v = new Variable(ctx, boolean.class);
+        assertEquals("my__thing", v.getVariableName());
+    }
+
+    @Disabled("Lies cannot be used in a variable name since it is a boolean alias")
+    @Test
+    public void shouldAllowLiesVariableNames() {
+        String program = """
+                Your lies is "hi"
+                Shout your lies
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
         Variable v = new Variable(ctx, boolean.class);

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/util/CapturingListener.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/util/CapturingListener.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class CapturingListener extends RockstarBaseListener {
     private Rockstar.AssignmentStmtContext assignmentStatement;
     private Rockstar.PoeticNumberLiteralContext poeticNumberLiteral;
-    private List<Rockstar.ExpressionContext> expressions = new ArrayList<>();
+    private final List<Rockstar.ExpressionContext> expressions = new ArrayList<>();
     private Rockstar.LiteralContext literal;
     private Rockstar.ConstantContext constant;
     private Rockstar.VariableContext variable;
@@ -21,6 +21,8 @@ public class CapturingListener extends RockstarBaseListener {
     private Rockstar.InputStmtContext input;
     private Rockstar.RoundingStmtContext rounding;
     private Rockstar.ArrayStmtContext array;
+
+    private Rockstar.StringStmtContext stringSplit;
 
     @Override
     public void enterAssignmentStmt(Rockstar.AssignmentStmtContext assignmentStatement) {
@@ -76,6 +78,11 @@ public class CapturingListener extends RockstarBaseListener {
         this.array = ctx;
     }
 
+    @Override
+    public void enterStringStmt(Rockstar.StringStmtContext ctx) {
+        this.stringSplit = ctx;
+    }
+
     public Rockstar.PoeticNumberLiteralContext getPoeticNumberLiteral() {
         return poeticNumberLiteral;
     }
@@ -114,5 +121,9 @@ public class CapturingListener extends RockstarBaseListener {
 
     public RuleContext getArray() {
         return array;
+    }
+
+    public RuleContext getStringSplit() {
+        return stringSplit;
     }
 }

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/util/ParseHelper.java
@@ -64,6 +64,11 @@ public class ParseHelper {
         return (Rockstar.ArrayStmtContext) getGrammarElement(program, CapturingListener::getArray);
     }
 
+
+    public Rockstar.StringStmtContext getStringSplit(String program) {
+        return (Rockstar.StringStmtContext) getGrammarElement(program, CapturingListener::getStringSplit);
+    }
+
     private RuleContext getGrammarElement(String program, Function<CapturingListener,
             RuleContext> getter) {
 /*


### PR DESCRIPTION
I've added support for splitting strings, but not for writing back the split string to the original variable. 

It turns out `Arrays.toList()` does not use the same `ArrayList` as the rest of the Java language, so I've had to switch from using `ArrayList` methods in `Array` to using the interface methods. 

I also noticed that `your lies` cannot be used as a variable because the `lies` is detected as a boolean, so I've added a disabled test for that.