### PR TITLE
Dynamic type support and basic casting implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ Some of these may work but have not been validated with tests.
 
 ## Casting
 
-- [ ] Conversion between types
+- [X] Casting strings to doubles
+- [ ] Casting using bases other than 10
+- [ ] Casting into a variable
+- [ ] Casting numbers to strings using UTF-8 conversions
 
 ## Single quotes
 

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
@@ -6,7 +6,7 @@ program: (NL|ws)* (statementList | functionDeclaration)* ws*;
 
 statementList: statement+;
 
-statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | arrayStmt | stringStmt | returnStmt | continueStmt | breakStmt) (NL+?|EOF);
+statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | arrayStmt | stringStmt | castStmt | returnStmt | continueStmt | breakStmt) (NL+?|EOF);
 
 expression: functionCall
           | lhe=expression ws op=(KW_MULTIPLY|KW_DIVIDE) ws rhe=expression
@@ -80,6 +80,8 @@ ups: KW_UP (COMMA? ws KW_UP)*;
 decrementStmt: KW_KNOCK ws variable ws downs;
 
 downs: KW_DOWN (COMMA? ws KW_DOWN)*;
+
+castStmt: KW_CAST ws variable;
 
 returnStmt: KW_GIVE (ws KW_BACK)? ws expression (ws KW_BACK)?;
 
@@ -187,4 +189,5 @@ allKeywords: KW_PUT
            | KW_AND
            | KW_OR
            | KW_NOR
+           | KW_CAST
 ;

--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/RockstarLexer.g4
@@ -138,6 +138,8 @@ KW_AT: A T;
 
 KW_SPLIT: C U T | S P L I T | S H A T T E R;
 
+KW_CAST: C A S T | B U R N;
+
 PROPER_NOUN: [A-Z][A-Z|a-z]*;
 WORD: [a-z|A-Z]+;
 

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Array.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Array.java
@@ -86,7 +86,7 @@ public class Array {
         // TODO it would be nice to specify the initial capacity, even if creating a collection to initialise it with is too tricky
         ResultHandle rh;
 
-        if (variable.isAlreadyDefined()) {
+        if (variable.isAlreadyWritten()) {
             rh = variable.read(method);
         } else {
             rh = method.newInstance(LIST_CONSTRUCTOR);

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Assignment.java
@@ -24,7 +24,7 @@ public class Assignment {
         if (ctx.KW_ROLL() != null) {
             value = null;
             variableClass = Object.class;
-            Variable source = new Variable(ctx.variable(0), Object.class);
+            Variable source = new Variable(ctx.variable(0), Array.TYPE_CLASS);
             arrayAccess = new Array(source);
 
             variable = new Variable(ctx.variable().get(1), variableClass);

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
@@ -8,28 +8,35 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.objectweb.asm.Opcodes;
 import rock.Rockstar;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Variable {
-    private static final Map<String, FieldDescriptor> variables = new HashMap<>();
-    private static final Map<String, Class> variableTypes = new HashMap<>();
+    private static final Map<String, Map<Class<?>, FieldDescriptor>> variables = new HashMap<>();
     // Because this is static, we could get cross-talk between programs, but that's a relatively low risk; we manage it by explicitly
     // clearing statics
     private static String mostRecentVariableName = null;
     private final String variableName;
-    private Class variableClass;
-
+    private Class<?> variableClass;
 
     public Variable(Rockstar.VariableContext variable, Class<?> variableClass) {
         this(variable, false);
 
         this.variableClass = variableClass;
-        if (!variableTypes.containsKey(variableName)) {
-            variableTypes.put(variableName, variableClass);
-        }
 
-        // TODO check the type if it exists, re-assign the variable name so we have truly dynamic types
+        if (!variables.containsKey(variableName)) {
+            Map<Class<?>, FieldDescriptor> map = new HashMap<>();
+            map.put(variableClass, null);
+            variables.put(variableName, map);
+        } else {
+            Map<Class<?>, FieldDescriptor> map = variables.get(variableName);
+            // Overwrite any previous type references
+            if (!map.containsKey(variableClass)) {
+                map.clear();
+                map.put(variableClass, null);
+            }
+        }
     }
 
     public Variable(Rockstar.VariableContext variable) {
@@ -55,8 +62,15 @@ public class Variable {
         }
 
         if (enforceType) {
-            if (variableTypes.containsKey(variableName)) {
-                variableClass = variableTypes.get(variableName);
+            Map<Class<?>, FieldDescriptor> map = variables.get(variableName);
+            if (map != null) {
+                if (map.size() == 1) {
+                    variableClass = map.keySet().iterator().next();
+                } else {
+                    String types = Arrays.toString(map.keySet().toArray());
+                    throw new RuntimeException(
+                            "The variable, " + variableName + " has been used as the following types, so we do not know which type this reference should be: " + types);
+                }
             } else {
                 throw new RuntimeException(
                         "Reference to a variable, " + variableName + ", but we do not have enough information about the type.");
@@ -76,7 +90,6 @@ public class Variable {
     public static void clearState() {
         mostRecentVariableName = null;
         variables.clear();
-        variableTypes.clear();
     }
 
     public Class<?> getVariableClass() {
@@ -98,39 +111,50 @@ public class Variable {
     }
 
     public ResultHandle read(BytecodeCreator method) {
-        if (isAlreadyDefined()) {
-            return method.readStaticField(variables.get(variableName));
-        } else {
-            // This is an internal error, not a program one
-            throw new RuntimeException("Moral panic: Could not find variable called " + variableName);
-        }
-    }
-
-    public boolean isAlreadyDefined() {
-        return variables.containsKey(variableName);
+        FieldDescriptor field = getField();
+        return method.readStaticField(field);
     }
 
     public void write(BytecodeCreator method, ClassCreator creator, ResultHandle value) {
-
-        FieldDescriptor field = getField(creator, method);
+        FieldDescriptor field = getOrCreateField(creator, method);
         method.writeStaticField(field, value);
     }
 
-    private FieldDescriptor getField(ClassCreator creator, BytecodeCreator method) {
+    public boolean isAlreadyWritten() {
+        Map<Class<?>, FieldDescriptor> classFieldDescriptorMap = variables.get(variableName);
+        return classFieldDescriptorMap != null && classFieldDescriptorMap.get(variableClass) != null;
+    }
+
+    private FieldDescriptor getField() {
         FieldDescriptor field;
-        if (!isAlreadyDefined()) {
+        if (isAlreadyWritten()) {
+            Map<Class<?>, FieldDescriptor> classFieldDescriptorMap = variables.get(variableName);
+            field = classFieldDescriptorMap.get(variableClass);
+        } else {
+            // This is an internal error, not a program one
+            throw new RuntimeException("Moral panic: Could not find variable called " + variableName + " of class " + variableClass);
+        }
+        return field;
+    }
+
+    private FieldDescriptor getOrCreateField(ClassCreator creator, BytecodeCreator method) {
+        FieldDescriptor field;
+        if (!isAlreadyWritten()) {
             // Variables are global in scope, so need to be stored at the class level (either as static or instance variables)
             field = creator.getFieldCreator(variableName, variableClass)
                     .setModifiers(Opcodes.ACC_STATIC + Opcodes.ACC_PRIVATE)
                     .getFieldDescriptor();
-            variables.put(variableName, field);
+            Map<Class<?>, FieldDescriptor> classFieldDescriptorMap = variables.get(variableName);
+            classFieldDescriptorMap.put(variableClass, field);
         } else {
-            field = variables.get(variableName);
+            field = getField();
             if (!creator.getClassName().equals(field.getDeclaringClass())) {
                 throw new RuntimeException("Internal error: Attempting to use a field on class " + field.getDeclaringClass() + " from " + creator.getClassName());
             }
         }
         return field;
     }
+
+
 }
 

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -1643,6 +1643,102 @@ names in Rockstar.)
         }
     }
 
+    @Nested
+    class Casting {
+        @Test
+        public void shouldCastDoubleToString() {
+            String program = """
+                    Let X be "123.45"
+                    Cast X
+                        (X now contains the numeric value 123.45)
+                    Say X
+                    Say X + 2 (casting really shows when doing math)
+                    """;
+            assertEquals("123.45\n125.45\n", compileAndLaunch(program));
+        }
+
+        @Test
+        public void shouldCastDoubleToStringUsingBurnAlias() {
+            String program = """
+                    Let X be "123.45"
+                    Burn X
+                        (X now contains the numeric value 123.45)
+                    Say X
+                    Say X + 2 (casting really shows when doing math)
+                    """;
+            assertEquals("123.45\n125.45\n", compileAndLaunch(program));
+        }
+
+        @Disabled("Not yet implemented")
+        @Test
+        public void shouldCastStringToDoubleWithConversionBases() {
+            String program = """
+                    Let X be "ff"
+                    Cast X with 16
+                        (X now contains the numeric value 255 - OxFF)
+                    Say X
+                    Say X + 2
+                                       
+                                        
+                    Cast "12345" into result
+                        (result now contains the number 12345)
+                    Cast "aa" into result with 16
+                        (result now contains the number 170 - 0xAA)
+                                        
+                    Cast 65 into result
+                        (result now contains the string "A" - ASCII code 65)
+                                        
+                    Cast 1046 into result
+                        (result now contains the Cyrillic letter "Ж" - Unicode code point 1046)
+                    """;
+            assertEquals("255\n257\n", compileAndLaunch(program));
+        }
+
+        @Disabled("Not yet implemented")
+        @Test
+        public void shouldCastIntoAVariable() {
+            String program = """             
+                    Cast "12345" into result
+                        (result now contains the number 12345)
+                    Say result
+                    Say result + 2
+                    Cast "aa" into result with 16
+                        (result now contains the number 170 - 0xAA)
+                    Say result
+                    Say result + 2
+                    """;
+            assertEquals("12345\n12347\n170\n172\n", compileAndLaunch(program));
+        }
+
+        @Disabled("Not yet implemented")
+        @Test
+        public void shouldCastNumbersIntoStringsAsUnicode() {
+            String program = """       
+                    Cast 65 into result
+                        (result now contains the string "A" - ASCII code 65)
+                    Say result
+                    Say result + 2
+                                        
+                    Cast 1046 into result
+                        (result now contains the Cyrillic letter "Ж" - Unicode code point 1046)
+                    Say result
+                    """;
+            assertEquals("A\nA2\nЖ\n", compileAndLaunch(program));
+        }
+    }
+
+    @Test
+    public void shouldUpdateTypeOnNewUsage() {
+        String program = """
+                my world is "octopus"
+                            my world is nothing
+                            Build my world up
+                            Build my world up
+                            say my world
+                """;
+        assertEquals("2\n", compileAndLaunch(program));
+    }
+
     private String compileAndLaunch(String program, String... args) {
         // Save the current System.out for later restoration
         PrintStream originalOut = System.out;

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/VariableTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/VariableTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VariableTest {
 
@@ -231,7 +232,33 @@ names in Rockstar.)
 
         // There is not an equals implementation beyond ==, so just compare the strings
         assertEquals(writtenValue.toString(), readValue.toString());
+    }
 
+    @Test
+    public void shouldAllowVariableTypeToChange() {
+        ClassCreator creator = ClassCreator.builder()
+                .className("holder")
+                .build();
+        MethodCreator method = creator.getMethodCreator("main", void.class, String[].class);
+
+        Rockstar.VariableContext ctx = new ParseHelper().getVariable("johnny is \"nice\"");
+        // The class here needs to match the class of what we load into the result handle
+        Variable variable = new Variable(ctx, String.class);
+        String className = "soundcheck";
+        ResultHandle writtenValue = method.load(className);
+        variable.write(method, creator, writtenValue);
+        ResultHandle readValue = variable.read(method);
+        assertTrue(readValue.toString().contains("type='Ljava/lang/String;'"), readValue.toString());
+
+        Rockstar.VariableContext ctx2 = new ParseHelper().getVariable("johnny is 4");
+        Variable variable2 = new Variable(ctx2, double.class);
+        // Sense check
+        assertEquals(double.class, variable2.getVariableClass());
+        ResultHandle writtenValue2 = method.load(2d);
+        variable2.write(method, creator, writtenValue2);
+        ResultHandle readValue2 = variable2.read(method);
+
+        assertTrue(readValue2.toString().contains("type='D'"), readValue2.toString());
     }
 
     @Test


### PR DESCRIPTION
Resolves #18; both test cases in that issue now pass. There is some more work to do around the edges of dynamic type support, such as allowing strings to be split in place, and full casting support, but the basics are in place. 

This PR also provides basic support for casting strings to doubles, using a normal base 10 conversion. 