### PR TITLE
Add thread sleeps to try and reduce flakiness of tests in CI

### DIFF
--- a/bon-jova-quarkus-extension/deployment/src/test/java/org/example/bon/jova/quarkus/extension/deployment/BonJovaQuarkusExtensionTest.java
+++ b/bon-jova-quarkus-extension/deployment/src/test/java/org/example/bon/jova/quarkus/extension/deployment/BonJovaQuarkusExtensionTest.java
@@ -55,7 +55,7 @@ public class BonJovaQuarkusExtensionTest {
     void testRockstarEndpoint() {
         // TODO Sleep in tests is the last resort of the desperate
         try {
-            Thread.sleep(500);
+            Thread.sleep(1500);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -79,7 +79,7 @@ public class BonJovaQuarkusExtensionTest {
     void testRockstarProgramWithArguments() {
         // TODO Sleep in tests is the last resort of the desperate
         try {
-            Thread.sleep(500);
+            Thread.sleep(1500);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/bon-jova-quarkus-extension/deployment/src/test/java/org/example/bon/jova/quarkus/extension/deployment/BonJovaQuarkusExtensionTest.java
+++ b/bon-jova-quarkus-extension/deployment/src/test/java/org/example/bon/jova/quarkus/extension/deployment/BonJovaQuarkusExtensionTest.java
@@ -53,6 +53,12 @@ public class BonJovaQuarkusExtensionTest {
 
     @Test
     void testRockstarEndpoint() {
+        // TODO Sleep in tests is the last resort of the desperate
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         RestAssured.when()
                 .get("/rockstar/hello_world.rock")
                 .then()
@@ -71,6 +77,13 @@ public class BonJovaQuarkusExtensionTest {
 
     @Test
     void testRockstarProgramWithArguments() {
+        // TODO Sleep in tests is the last resort of the desperate
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         RestAssured.when()
                 .get("/rockstar/hello_hanno_hello_holly.rock?arg=Hanno&arg=Holly")
                 .then()


### PR DESCRIPTION
Resolves #76. I think the issue is that as more Rockstar features are supported, compilation is getting slower. 

That's not ideal for a number of reasons. In the short term, it affects the tests because the code isn't ready when the test asks for it. 

I've done a tactical fix of a thread sleep, which we can revisit later. 