### PR TITLE
Tolerate constants in poetic number literals, except as the first word

### DIFF
--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
@@ -109,22 +109,32 @@ variable: COMMON_VARIABLE_PREFIXES ws WORD
         | PRONOUNS
 ;
 
-poeticNumberLiteral: poeticNumberLiteralWord poeticNumberLiteralGarbage* poeticNumberLiteralDecimalSeparator? (ws poeticNumberLiteralGarbage* ws* poeticNumberLiteralWord poeticNumberLiteralGarbage* poeticNumberLiteralDecimalSeparator?)*;
+poeticNumberLiteral: poeticNumberLiteralLeadingWord poeticNumberLiteralGarbage* poeticNumberLiteralDecimalSeparator? (ws poeticNumberLiteralGarbage* ws* poeticNumberLiteralWord poeticNumberLiteralGarbage* poeticNumberLiteralDecimalSeparator?)*;
 
 poeticNumberLiteralGarbage: ws* (COMMA | EXCLAMATION_MARK | QUESTION_MARK | PLUS_SIGN | AMPERSAND | SINGLE_QUOTE) ws*
 ;
 
-poeticNumberLiteralWord: poeticNumberLiteralWord HYPHEN poeticNumberLiteralWord
-                       | poeticNumberLiteralWord SINGLE_QUOTE poeticNumberLiteralWord?
-                       | poeticNumberLiteralWord APOSTROPHE_S poeticNumberLiteralWord?
-                       | poeticNumberLiteralWord APOSTROPHE_RE poeticNumberLiteralWord?
-                       | poeticNumberLiteralWord APOSTROPHED_N poeticNumberLiteralWord?
-                       | SINGLE_QUOTE poeticNumberLiteralWord
+poeticNumberLiteralLeadingWord: poeticNumberLiteralLeadingWord HYPHEN poeticNumberLiteralLeadingWord
+                       | poeticNumberLiteralLeadingWord SINGLE_QUOTE poeticNumberLiteralLeadingWord?
+                       | poeticNumberLiteralLeadingWord APOSTROPHE_S poeticNumberLiteralLeadingWord?
+                       | poeticNumberLiteralLeadingWord APOSTROPHE_RE poeticNumberLiteralLeadingWord?
+                       | poeticNumberLiteralLeadingWord APOSTROPHED_N poeticNumberLiteralLeadingWord?
+                       | SINGLE_QUOTE poeticNumberLiteralLeadingWord
                        | COMMON_VARIABLE_PREFIXES
                        | allKeywords
                        | PRONOUNS
                        | WORD
                        | PROPER_NOUN
+;
+
+
+poeticNumberLiteralWord: poeticNumberLiteralLeadingWord
+                        | poeticNumberLiteralWord HYPHEN poeticNumberLiteralWord
+                         | poeticNumberLiteralWord SINGLE_QUOTE poeticNumberLiteralWord?
+                         | poeticNumberLiteralWord APOSTROPHE_S poeticNumberLiteralWord?
+                         | poeticNumberLiteralWord APOSTROPHE_RE poeticNumberLiteralWord?
+                         | poeticNumberLiteralWord APOSTROPHED_N poeticNumberLiteralWord?
+                       | allConstants
 ;
 
 poeticNumberLiteralDecimalSeparator: DOT;
@@ -142,15 +152,19 @@ poeticStringLiteralGarbage: DOT
 
 poeticStringLiteralWord: COMMON_VARIABLE_PREFIXES
                        | PRONOUNS
-                       | CONSTANT_UNDEFINED
-                       | CONSTANT_NULL
-                       | CONSTANT_TRUE
-                       | CONSTANT_FALSE
+                       | allConstants
                        | allKeywords
                        | WORD
                        | WORD_WITH_QUOTES
                        | PROPER_NOUN
 ;
+
+allConstants:  CONSTANT_UNDEFINED
+                       | CONSTANT_NULL
+                       | CONSTANT_TRUE
+                       | CONSTANT_FALSE
+;
+
 
 allKeywords: KW_PUT
            | KW_INTO

--- a/bon-jova-rockstar-implementation/src/main/java/org/example/grammar/PoeticNumberLiteral.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/grammar/PoeticNumberLiteral.java
@@ -14,7 +14,9 @@ public class PoeticNumberLiteral {
         // values of consecutive digits are given by the lengths of the subsequent barewords, up until the end of the line.
         // To allow the digit zero, and to compensate for a lack of suitably rock'n'roll 1- and 2-letter words, word lengths are
         // parsed modulo 10.
-        String string = ctx
+
+        String string = wordToNumber(ctx
+                .poeticNumberLiteralLeadingWord()) + ctx
                 .poeticNumberLiteralWord()
                 .stream()
                 .map(word -> wordToNumber(word))
@@ -35,7 +37,7 @@ public class PoeticNumberLiteral {
                 var child = ctx.getChild(i);
                 if (child == dot) {
                     break;
-                } else if (child instanceof Rockstar.PoeticNumberLiteralWordContext) {
+                } else if (child instanceof Rockstar.PoeticNumberLiteralWordContext || child instanceof Rockstar.PoeticNumberLiteralLeadingWordContext) {
                     // Only count words, not garbage or whitespace
                     index++;
                 }
@@ -54,12 +56,22 @@ public class PoeticNumberLiteral {
 
     }
 
-    private static String wordToNumber(Rockstar.PoeticNumberLiteralWordContext word) {
+
+    private static String textToNumber(String word) {
         // Ignore apostrophes; because they can be in the middle of the word this is hard to do in the grammar
-        int length = word.getText()
+        int length = word
                 .replaceAll("'", "")
                 .length();
         return String.valueOf(Math.floorMod(length, 10));
+    }
+
+    private static String wordToNumber(Rockstar.PoeticNumberLiteralLeadingWordContext word) {
+        return textToNumber(word.getText());
+    }
+
+    private static String wordToNumber(Rockstar.PoeticNumberLiteralWordContext word) {
+        // Ignore apostrophes; because they can be in the middle of the word this is hard to do in the grammar
+        return textToNumber(word.getText());
     }
 
     public Class<?> getVariableClass() {

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -288,6 +288,17 @@ names in Rockstar.)
         assertEquals(leet, output);
     }
 
+    // As long as the next symbol is not a Literal Word, the rest of the line is treated as a decimal number in which the values of consecutive digits are given by the lengths of the subsequent barewords, up until the end of the line.
+    @Test
+    public void shouldHandleNoInPoeticLiterals() {
+        String program = """
+                The tide is low. A ball flung-about, beach abandoned, no soiree beats the shore
+                                             Whisper the tide
+                                """;
+        assertEquals("3.141592654\n", compileAndLaunch(program));
+
+    }
+
     /*
      * Put 123 into X will assign the value 123 to the variable X
      */


### PR DESCRIPTION
The spec says 

> A poetic number literal begins with a variable name, followed by the keyword is, or the aliases are, was or were. As long as the next symbol is not a Literal Word, the rest of the line is treated as a decimal number in which the values of consecutive digits are given by the lengths of the subsequent barewords, up until the end of the line.

I've now fixed the implementation. It's the risky sort of fix where something else might regress, so be aware. Hopefully the tests caught everything! It was lucky the second word in your example was 'low', @hannotify, since my fix initially broke toleration for that word ... but your example caught it (phew!).