### PR TITLE
Do not discard existing fields when we narrow the type of a variable

### DIFF
--- a/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
+++ b/bon-jova-rockstar-implementation/src/main/java/org/example/Variable.java
@@ -42,10 +42,15 @@ public class Variable {
             variables.put(this.variableName, map);
         } else {
             Map<Class<?>, FieldDescriptor> map = variables.get(this.variableName);
-            // Overwrite any previous type references
+            // Overwrite any previous type references, if we can't work with them
+            // If it's an object, just keep it and accept that we optimistically narrowed it
+            // TODO this is probably still quite fragile
+            // TODO we need a unit test for this - or six
+            FieldDescriptor oldField = map.get(Object.class);
+
             if (!map.containsKey(variableClass)) {
                 map.clear();
-                map.put(variableClass, null);
+                map.put(variableClass, oldField);
             }
         }
     }
@@ -171,7 +176,5 @@ public class Variable {
         }
         return field;
     }
-
-
 }
 


### PR DESCRIPTION
I noticed when testing 1brc that we have a problem reading arrays, sometimes, because of interference with the support for dynamically changing the type of a variable; there's a difference between compatible type changes, when we want to keep the field, and incompatible changes, when we want to throw it out. 

I've put in a fix, but we should also add more tests and maybe something overall more robust.